### PR TITLE
feat: 詳細スコア入力の保存機能を実装

### DIFF
--- a/src/app/input/detailed/components/step-scoring.tsx
+++ b/src/app/input/detailed/components/step-scoring.tsx
@@ -56,6 +56,7 @@ interface StepScoringProps {
   selectedCourse: CourseWithDetails | null;
   currentHole: number;
   isSaving: boolean;
+  error: string;
   onCurrentHoleChange: (hole: number) => void;
   onUpdateHole: (hole: HoleData) => void;
   onSave: () => void;
@@ -70,6 +71,7 @@ export function StepScoring({
   selectedCourse,
   currentHole,
   isSaving,
+  error,
   onCurrentHoleChange,
   onUpdateHole,
   onSave,
@@ -501,6 +503,13 @@ export function StepScoring({
             <ChevronRight className="w-5 h-5 ml-1" />
           </Button>
         </div>
+
+        {/* エラーメッセージ */}
+        {error && (
+          <div className="px-4 pb-2">
+            <p className="text-sm text-destructive">{error}</p>
+          </div>
+        )}
 
         {/* 操作ボタン */}
         <div className="flex gap-2 px-4 pb-4">

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -90,7 +90,7 @@ export interface CourseWithDetails extends Course {
 export interface Round {
   id: string;
   member_id: string;
-  course_id: string;
+  course_id: string | null;
   date: string;
   tee_color: TeeColor;
   weather: string | null;
@@ -101,7 +101,7 @@ export interface Score {
   id: string;
   round_id: string;
   hole_number: number;
-  par: 3 | 4 | 5;
+  par: 3 | 4 | 5 | 6;
   distance: number | null;
   score: number;
   putts: number;
@@ -110,11 +110,12 @@ export interface Score {
   bunker: number;
   penalty: number;
   pin_position: PinPosition | null;
+  shots_detail: unknown[] | null;
 }
 
 /** Round with nested scores and course info */
 export interface RoundWithDetails extends Round {
-  course: Course;
+  course: Course | null;
   scores: Score[];
 }
 

--- a/src/utils/shot-aggregation.ts
+++ b/src/utils/shot-aggregation.ts
@@ -1,0 +1,114 @@
+import { HoleData, TeeShot, ApproachShot } from "@/types/shot";
+import { FairwayResult, PinPosition } from "@/types/database";
+
+/** scores テーブルに挿入する1行分のデータ */
+export interface AggregatedScore {
+  hole_number: number;
+  par: number;
+  distance: number | null;
+  score: number;
+  putts: number;
+  fairway_result: FairwayResult;
+  ob: number;
+  bunker: number;
+  penalty: number;
+  pin_position: PinPosition | null;
+  shots_detail: unknown[];
+}
+
+/**
+ * HoleData（ショット配列付き）を scores テーブルのフラットレコードに変換する
+ */
+export function aggregateHoleData(hole: HoleData): AggregatedScore {
+  const score = hole.shots.length;
+  const putts = hole.shots.filter((s) => s.type === "putt").length;
+  const fairway_result = deriveFairwayResult(hole);
+  const ob = countOB(hole);
+  const bunker = countBunker(hole);
+  const penalty = countPenalty(hole);
+
+  return {
+    hole_number: hole.holeNumber,
+    par: hole.par,
+    distance: hole.distance,
+    score,
+    putts,
+    fairway_result,
+    ob,
+    bunker,
+    penalty,
+    pin_position: hole.pinPosition,
+    shots_detail: hole.shots,
+  };
+}
+
+/**
+ * フェアウェイ結果を算出
+ * - Par 3 → 常に keep（フェアウェイキープはPar4+の概念）
+ * - ティーショットの result + resultDirection から判定
+ */
+function deriveFairwayResult(hole: HoleData): FairwayResult {
+  if (hole.par === 3) return "keep";
+
+  const teeShot = hole.shots.find((s) => s.type === "tee") as TeeShot | undefined;
+  if (!teeShot) return "keep";
+
+  switch (teeShot.result) {
+    case "fairway":
+      return "keep";
+    case "rough":
+    case "bunker":
+    case "penalty":
+      return teeShot.resultDirection === "right" ? "right" : "left";
+    case "ob":
+      return teeShot.resultDirection === "right" ? "right" : "left";
+    default:
+      return "keep";
+  }
+}
+
+/** OB数を集計: TeeShot(result=ob) + ApproachShot(result=ob-*) */
+function countOB(hole: HoleData): number {
+  let count = 0;
+  for (const shot of hole.shots) {
+    if (shot.type === "tee" && shot.result === "ob") {
+      count++;
+    } else if (shot.type === "approach") {
+      const approach = shot as ApproachShot;
+      if (approach.result === "ob-left" || approach.result === "ob-right") {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+/** バンカー数を集計: ApproachShot(lie=left-bunker or right-bunker) */
+function countBunker(hole: HoleData): number {
+  let count = 0;
+  for (const shot of hole.shots) {
+    if (shot.type === "approach") {
+      const approach = shot as ApproachShot;
+      if (approach.lie === "left-bunker" || approach.lie === "right-bunker") {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
+/** ペナルティ数を集計: TeeShot(result=penalty) + ApproachShot(result=penalty-*) */
+function countPenalty(hole: HoleData): number {
+  let count = 0;
+  for (const shot of hole.shots) {
+    if (shot.type === "tee" && shot.result === "penalty") {
+      count++;
+    } else if (shot.type === "approach") {
+      const approach = shot as ApproachShot;
+      if (approach.result === "penalty-left" || approach.result === "penalty-right") {
+        count++;
+      }
+    }
+  }
+  return count;
+}

--- a/supabase/005_detailed_scores.sql
+++ b/supabase/005_detailed_scores.sql
@@ -1,0 +1,15 @@
+-- 詳細ショット入力対応のスキーマ変更
+
+-- hole_number: 18→36 (27ホールラウンド対応)
+ALTER TABLE scores DROP CONSTRAINT scores_hole_number_check;
+ALTER TABLE scores ADD CONSTRAINT scores_hole_number_check CHECK (hole_number BETWEEN 1 AND 36);
+
+-- par: 3,4,5 → 3,4,5,6
+ALTER TABLE scores DROP CONSTRAINT scores_par_check;
+ALTER TABLE scores ADD CONSTRAINT scores_par_check CHECK (par BETWEEN 3 AND 6);
+
+-- course_id: NOT NULL → nullable（手動入力コース対応）
+ALTER TABLE rounds ALTER COLUMN course_id DROP NOT NULL;
+
+-- shots_detail: ショット配列をJSONBで保存（MVP）
+ALTER TABLE scores ADD COLUMN IF NOT EXISTS shots_detail JSONB;


### PR DESCRIPTION
## Summary

- 詳細スコア入力（`/input/detailed`）の未実装だった `handleSave` を実装
- ショット単位の入力データを `rounds` + `scores` テーブルに保存し、ランキング・統計に反映
- 既存OCR入力（`/input`）と同じ保存パターンを踏襲

### 変更内容

- **DBマイグレーション** (`supabase/005_detailed_scores.sql`): `hole_number` 36対応、`par` 6対応、`course_id` nullable化、`shots_detail` JSONB カラム追加
- **型定義更新** (`src/types/database.ts`): `Score.par` 拡張、`shots_detail` 追加、`Round.course_id` nullable
- **ショット集約ユーティリティ** (`src/utils/shot-aggregation.ts`): `HoleData` → `scores` テーブルのフラットレコード変換（score, putts, fairway_result, ob, bunker, penalty を算出）
- **handleSave実装** (`src/app/input/detailed/page.tsx`): バリデーション → course_id解決 → rounds insert → scores bulk insert → ドラフト削除 → `/my-stats` リダイレクト
- **エラー表示** (`step-scoring.tsx`): フッターにエラーメッセージ表示、`RequireAuth` ラップ追加

## Test plan

- [ ] 詳細入力で全ホールにショットを入力し、保存ボタンで `/my-stats` にリダイレクトされること
- [ ] 保存後、ランキングページに新しいラウンドデータが反映されること
- [ ] コース未入力時にエラーメッセージが表示されること
- [ ] ショット未入力のホールがある場合にエラーメッセージが表示されること
- [ ] 手動入力コース（DBに存在しないコース名）でも保存できること
- [ ] `npm run build` がエラーなく通ること

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)