### PR TITLE
feat: マイページにコース詳細分析タブを追加

### DIFF
--- a/src/app/my-stats/page.tsx
+++ b/src/app/my-stats/page.tsx
@@ -8,8 +8,10 @@ import { useAuth } from "@/contexts/auth-context";
 import { supabase } from "@/lib/supabase";
 import { MemberStats, ClubType, Gender, PreferredTee } from "@/types/database";
 import { calculateMemberStats } from "@/utils/ranking";
-import { calculateRadarData, calculateHoleAnalysis, RadarChartData, HoleAnalysis } from "@/utils/stats";
+import { calculateRadarData, calculateHoleAnalysis, calculateHoleScoreTrend, RadarChartData, HoleAnalysis, HoleScoreTrend } from "@/utils/stats";
 import { ClubSetEditor } from "@/components/club-set-editor";
+import { CourseAnalysisTab } from "@/components/course-analysis-tab";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Loader2, Sparkles, Settings, Check, ChevronDown, ChevronUp } from "lucide-react";
 import {
   Radar,
@@ -24,6 +26,10 @@ import {
   YAxis,
   Tooltip,
   Cell,
+  LineChart,
+  Line,
+  ReferenceLine,
+  CartesianGrid,
 } from "recharts";
 
 export default function MyStatsPage() {
@@ -40,6 +46,7 @@ function MyStatsContent() {
   const [allStats, setAllStats] = useState<MemberStats[]>([]);
   const [radarData, setRadarData] = useState<RadarChartData[]>([]);
   const [holeAnalysis, setHoleAnalysis] = useState<HoleAnalysis[]>([]);
+  const [holeScoreTrend, setHoleScoreTrend] = useState<HoleScoreTrend[]>([]);
   const [advice, setAdvice] = useState<string>("");
   const [isLoadingAdvice, setIsLoadingAdvice] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
@@ -111,7 +118,7 @@ function MyStatsContent() {
           member_id,
           date,
           members!inner(name),
-          scores(par, score, putts, fairway_result)
+          scores(hole_number, par, score, putts, fairway_result)
         `
         )
         .order("date", { ascending: false });
@@ -127,6 +134,7 @@ function MyStatsContent() {
         member_id: r.member_id,
         member_name: (r.members as unknown as { name: string }).name,
         scores: r.scores as {
+          hole_number: number;
           par: number;
           score: number;
           putts: number;
@@ -145,10 +153,11 @@ function MyStatsContent() {
         setRadarData(calculateRadarData(myMemberStats, calculatedStats));
       }
 
-      // Calculate hole analysis for my rounds
+      // Calculate hole analysis and trend for my rounds
       const myRounds = roundData.filter((r) => r.member_id === member?.id).slice(0, 5);
       const allMyScores = myRounds.flatMap((r) => r.scores);
       setHoleAnalysis(calculateHoleAnalysis(allMyScores));
+      setHoleScoreTrend(calculateHoleScoreTrend(allMyScores));
 
       setIsLoading(false);
     }
@@ -313,140 +322,201 @@ function MyStatsContent() {
     <div className="space-y-6">
       <h2 className="text-2xl font-bold">マイページ</h2>
       <p className="text-sm text-muted-foreground">
-        {member?.name}さんのスタッツと分析結果（直近5ラウンド）
+        {member?.name}さんのスタッツと分析結果
       </p>
 
-      <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>能力レーダーチャート</CardTitle>
-            <p className="text-xs text-muted-foreground">部内平均=50の偏差値表示</p>
-          </CardHeader>
-          <CardContent className="h-72">
-            {radarData.length > 0 ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <RadarChart data={radarData}>
-                  <PolarGrid />
-                  <PolarAngleAxis dataKey="category" tick={{ fontSize: 12 }} />
-                  <PolarRadiusAxis angle={90} domain={[20, 80]} tick={{ fontSize: 10 }} />
-                  <Radar
-                    name="能力値"
-                    dataKey="value"
-                    stroke="#22c55e"
-                    fill="#22c55e"
-                    fillOpacity={0.5}
-                  />
-                </RadarChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="flex items-center justify-center h-full text-muted-foreground">
-                データが不足しています
-              </div>
-            )}
-          </CardContent>
-        </Card>
+      <Tabs defaultValue="overall">
+        <TabsList className="grid grid-cols-2 w-full">
+          <TabsTrigger value="overall">総合分析</TabsTrigger>
+          <TabsTrigger value="course">コース詳細分析</TabsTrigger>
+        </TabsList>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>ホール別分析</CardTitle>
-            <p className="text-xs text-muted-foreground">Par別の平均スコア</p>
-          </CardHeader>
-          <CardContent className="h-72">
-            {holeAnalysis.some((h) => h.count > 0) ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={holeAnalysis} layout="vertical">
-                  <XAxis type="number" domain={[0, "auto"]} />
-                  <YAxis type="category" dataKey="parType" width={50} />
-                  <Tooltip
-                    formatter={(value) => [Number(value).toFixed(2), "平均スコア"]}
-                    labelFormatter={(label) => label}
-                  />
-                  <Bar dataKey="avgScore" radius={[0, 4, 4, 0]}>
-                    {holeAnalysis.map((_, index) => (
-                      <Cell key={`cell-${index}`} fill={barColors[index]} />
-                    ))}
-                  </Bar>
-                </BarChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="flex items-center justify-center h-full text-muted-foreground">
-                データが不足しています
-              </div>
-            )}
-          </CardContent>
-        </Card>
-      </div>
+        <TabsContent value="overall" className="space-y-6 mt-4">
+          <p className="text-xs text-muted-foreground">直近5ラウンド</p>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-primary" />
-            AIコーチ
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {!advice && !isLoadingAdvice && (
-            <Button onClick={generateAdvice} className="w-full md:w-auto">
-              <Sparkles className="h-4 w-4 mr-2" />
-              アドバイスを生成
-            </Button>
-          )}
-          {isLoadingAdvice && (
-            <div className="flex items-center gap-2 text-muted-foreground">
-              <Loader2 className="h-4 w-4 animate-spin" />
-              アドバイスを生成中...
-            </div>
-          )}
-          {advice && (
-            <div className="prose prose-sm max-w-none">
-              <p className="whitespace-pre-wrap">{advice}</p>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={generateAdvice}
-                className="mt-4"
-                disabled={isLoadingAdvice}
-              >
-                再生成
-              </Button>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+          <div className="grid gap-4 md:grid-cols-2">
+            <Card>
+              <CardHeader>
+                <CardTitle>能力レーダーチャート</CardTitle>
+                <p className="text-xs text-muted-foreground">部内平均=50の偏差値表示</p>
+              </CardHeader>
+              <CardContent className="h-72">
+                {radarData.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <RadarChart data={radarData}>
+                      <PolarGrid />
+                      <PolarAngleAxis dataKey="category" tick={{ fontSize: 12 }} />
+                      <PolarRadiusAxis angle={90} domain={[20, 80]} tick={{ fontSize: 10 }} />
+                      <Radar
+                        name="能力値"
+                        dataKey="value"
+                        stroke="#22c55e"
+                        fill="#22c55e"
+                        fillOpacity={0.5}
+                      />
+                    </RadarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="flex items-center justify-center h-full text-muted-foreground">
+                    データが不足しています
+                  </div>
+                )}
+              </CardContent>
+            </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>スタッツ詳細</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-            <div className="p-4 bg-muted/50 rounded-lg">
-              <p className="text-sm text-muted-foreground">平均スコア</p>
-              <p className="text-2xl font-bold">{myStats.avg_score.toFixed(1)}</p>
-            </div>
-            <div className="p-4 bg-muted/50 rounded-lg">
-              <p className="text-sm text-muted-foreground">平均パット</p>
-              <p className="text-2xl font-bold">{myStats.avg_putts.toFixed(1)}</p>
-            </div>
-            <div className="p-4 bg-muted/50 rounded-lg">
-              <p className="text-sm text-muted-foreground">パーオン率</p>
-              <p className="text-2xl font-bold">{myStats.gir_rate.toFixed(1)}%</p>
-            </div>
-            <div className="p-4 bg-muted/50 rounded-lg">
-              <p className="text-sm text-muted-foreground">FWキープ率</p>
-              <p className="text-2xl font-bold">{myStats.fairway_keep_rate.toFixed(1)}%</p>
-            </div>
-            <div className="p-4 bg-muted/50 rounded-lg">
-              <p className="text-sm text-muted-foreground">平均バーディー</p>
-              <p className="text-2xl font-bold">{myStats.avg_birdies.toFixed(2)}</p>
-            </div>
-            <div className="p-4 bg-muted/50 rounded-lg">
-              <p className="text-sm text-muted-foreground">リカバリー率</p>
-              <p className="text-2xl font-bold">{myStats.scramble_rate.toFixed(1)}%</p>
-            </div>
+            <Card>
+              <CardHeader>
+                <CardTitle>ホール別分析</CardTitle>
+                <p className="text-xs text-muted-foreground">Par別の平均スコア</p>
+              </CardHeader>
+              <CardContent className="h-72">
+                {holeAnalysis.some((h) => h.count > 0) ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={holeAnalysis} layout="vertical">
+                      <XAxis type="number" domain={[0, "auto"]} />
+                      <YAxis type="category" dataKey="parType" width={50} />
+                      <Tooltip
+                        formatter={(value) => [Number(value).toFixed(2), "平均スコア"]}
+                        labelFormatter={(label) => label}
+                      />
+                      <Bar dataKey="avgScore" radius={[0, 4, 4, 0]}>
+                        {holeAnalysis.map((_, index) => (
+                          <Cell key={`cell-${index}`} fill={barColors[index]} />
+                        ))}
+                      </Bar>
+                    </BarChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="flex items-center justify-center h-full text-muted-foreground">
+                    データが不足しています
+                  </div>
+                )}
+              </CardContent>
+            </Card>
           </div>
-        </CardContent>
-      </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>ホール別スコア推移</CardTitle>
+              <p className="text-xs text-muted-foreground">各ホールの平均オーバーパー（直近5ラウンド）</p>
+            </CardHeader>
+            <CardContent className="h-72">
+              {holeScoreTrend.some((h) => h.count > 0) ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={holeScoreTrend}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="hole"
+                      tick={{ fontSize: 12 }}
+                      label={{ value: "ホール", position: "insideBottomRight", offset: -5, fontSize: 11 }}
+                    />
+                    <YAxis
+                      tick={{ fontSize: 12 }}
+                      tickFormatter={(v: number) => (v > 0 ? `+${v}` : `${v}`)}
+                      label={{ value: "±パー", angle: -90, position: "insideLeft", fontSize: 11 }}
+                    />
+                    <Tooltip
+                      formatter={(value) => {
+                        const v = Number(value);
+                        return [(v > 0 ? "+" : "") + v.toFixed(2), "平均オーバーパー"];
+                      }}
+                      labelFormatter={(label) => `Hole ${label}`}
+                    />
+                    <ReferenceLine y={0} stroke="#888" strokeDasharray="3 3" label={{ value: "Par", position: "right", fontSize: 11 }} />
+                    <Line
+                      type="monotone"
+                      dataKey="avgOverPar"
+                      stroke="#22c55e"
+                      strokeWidth={2}
+                      dot={{ r: 3, fill: "#22c55e" }}
+                      activeDot={{ r: 5 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  データが不足しています
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Sparkles className="h-5 w-5 text-primary" />
+                AIコーチ
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {!advice && !isLoadingAdvice && (
+                <Button onClick={generateAdvice} className="w-full md:w-auto">
+                  <Sparkles className="h-4 w-4 mr-2" />
+                  アドバイスを生成
+                </Button>
+              )}
+              {isLoadingAdvice && (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  アドバイスを生成中...
+                </div>
+              )}
+              {advice && (
+                <div className="prose prose-sm max-w-none">
+                  <p className="whitespace-pre-wrap">{advice}</p>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={generateAdvice}
+                    className="mt-4"
+                    disabled={isLoadingAdvice}
+                  >
+                    再生成
+                  </Button>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>スタッツ詳細</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                <div className="p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">平均スコア</p>
+                  <p className="text-2xl font-bold">{myStats.avg_score.toFixed(1)}</p>
+                </div>
+                <div className="p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">平均パット</p>
+                  <p className="text-2xl font-bold">{myStats.avg_putts.toFixed(1)}</p>
+                </div>
+                <div className="p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">パーオン率</p>
+                  <p className="text-2xl font-bold">{myStats.gir_rate.toFixed(1)}%</p>
+                </div>
+                <div className="p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">FWキープ率</p>
+                  <p className="text-2xl font-bold">{myStats.fairway_keep_rate.toFixed(1)}%</p>
+                </div>
+                <div className="p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">平均バーディー</p>
+                  <p className="text-2xl font-bold">{myStats.avg_birdies.toFixed(2)}</p>
+                </div>
+                <div className="p-4 bg-muted/50 rounded-lg">
+                  <p className="text-sm text-muted-foreground">リカバリー率</p>
+                  <p className="text-2xl font-bold">{myStats.scramble_rate.toFixed(1)}%</p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="course" className="mt-4">
+          <CourseAnalysisTab memberId={member!.id} />
+        </TabsContent>
+      </Tabs>
 
       {/* Profile Settings */}
       <Card>

--- a/src/components/course-analysis-tab.tsx
+++ b/src/components/course-analysis-tab.tsx
@@ -1,0 +1,629 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { supabase } from "@/lib/supabase";
+import { PinPosition } from "@/types/database";
+import {
+  calculateCourseBasicStats,
+  calculateScoreDistribution,
+  calculateHoleScorePattern,
+  calculateTeeShotTendency,
+  calculateApproachClubs,
+  calculatePinPositionScores,
+  CourseBasicStats,
+} from "@/utils/course-stats";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ReferenceLine,
+} from "recharts";
+import { Loader2 } from "lucide-react";
+
+interface CourseOption {
+  id: string;
+  name: string;
+  pref: string | null;
+}
+
+interface ScoreRow {
+  hole_number: number;
+  par: number;
+  score: number;
+  putts: number;
+  fairway_result: string;
+  pin_position: PinPosition | null;
+  shots_detail: unknown[] | null;
+}
+
+interface RoundWithScores {
+  id: string;
+  date: string;
+  scores: ScoreRow[];
+}
+
+interface CourseAnalysisTabProps {
+  memberId: string;
+}
+
+const PIE_COLORS = {
+  eagle: "#16a34a",
+  birdie: "#22c55e",
+  par: "#3b82f6",
+  bogey: "#f59e0b",
+  doublePlus: "#ef4444",
+};
+
+const PIN_POSITIONS: { key: PinPosition; label: string; row: number; col: number }[] = [
+  { key: "front-left", label: "FL", row: 0, col: 0 },
+  { key: "front-center", label: "FC", row: 0, col: 1 },
+  { key: "front-right", label: "FR", row: 0, col: 2 },
+  { key: "middle-left", label: "ML", row: 1, col: 0 },
+  { key: "center", label: "C", row: 1, col: 1 },
+  { key: "middle-right", label: "MR", row: 1, col: 2 },
+  { key: "back-left", label: "BL", row: 2, col: 0 },
+  { key: "back-center", label: "BC", row: 2, col: 1 },
+  { key: "back-right", label: "BR", row: 2, col: 2 },
+];
+
+function getPinColor(avgOverPar: number | null): string {
+  if (avgOverPar === null) return "bg-muted text-muted-foreground";
+  if (avgOverPar <= 0) return "bg-green-500 text-white";
+  if (avgOverPar <= 1) return "bg-yellow-400 text-gray-900";
+  return "bg-red-500 text-white";
+}
+
+export function CourseAnalysisTab({ memberId }: CourseAnalysisTabProps) {
+  const [courses, setCourses] = useState<CourseOption[]>([]);
+  const [selectedCourseId, setSelectedCourseId] = useState<string>("");
+  const [myRounds, setMyRounds] = useState<RoundWithScores[]>([]);
+  const [teamRounds, setTeamRounds] = useState<{ scores: ScoreRow[] }[]>([]);
+  const [selectedHole, setSelectedHole] = useState<number | null>(null);
+  const [isLoadingCourses, setIsLoadingCourses] = useState(true);
+  const [isLoadingData, setIsLoadingData] = useState(false);
+
+  // Fetch played courses
+  useEffect(() => {
+    async function fetchCourses() {
+      const { data, error } = await supabase
+        .from("rounds")
+        .select("course_id, courses!inner(id, name, pref)")
+        .eq("member_id", memberId)
+        .not("course_id", "is", null);
+
+      if (error) {
+        console.error("Failed to fetch courses:", error);
+        setIsLoadingCourses(false);
+        return;
+      }
+
+      const courseMap = new Map<string, CourseOption>();
+      for (const row of data ?? []) {
+        const course = row.courses as unknown as { id: string; name: string; pref: string | null };
+        if (!courseMap.has(course.id)) {
+          courseMap.set(course.id, { id: course.id, name: course.name, pref: course.pref });
+        }
+      }
+
+      setCourses(Array.from(courseMap.values()).sort((a, b) => a.name.localeCompare(b.name)));
+      setIsLoadingCourses(false);
+    }
+
+    fetchCourses();
+  }, [memberId]);
+
+  // Fetch data when course is selected
+  useEffect(() => {
+    if (!selectedCourseId) return;
+
+    async function fetchCourseData() {
+      setIsLoadingData(true);
+      setSelectedHole(null);
+
+      const [myResult, teamResult] = await Promise.all([
+        supabase
+          .from("rounds")
+          .select("id, date, scores(hole_number, par, score, putts, fairway_result, pin_position, shots_detail)")
+          .eq("member_id", memberId)
+          .eq("course_id", selectedCourseId)
+          .order("date", { ascending: false }),
+        supabase
+          .from("rounds")
+          .select("id, member_id, scores(hole_number, par, score, putts, fairway_result)")
+          .eq("course_id", selectedCourseId)
+          .order("date", { ascending: false }),
+      ]);
+
+      if (myResult.error) {
+        console.error("Failed to fetch my rounds:", myResult.error);
+      } else {
+        setMyRounds(
+          (myResult.data ?? []).map((r) => ({
+            id: r.id,
+            date: r.date,
+            scores: (r.scores as ScoreRow[]) ?? [],
+          }))
+        );
+      }
+
+      if (teamResult.error) {
+        console.error("Failed to fetch team rounds:", teamResult.error);
+      } else {
+        setTeamRounds(
+          (teamResult.data ?? []).map((r) => ({
+            scores: (r.scores as unknown as ScoreRow[]) ?? [],
+          }))
+        );
+      }
+
+      setIsLoadingData(false);
+    }
+
+    fetchCourseData();
+  }, [memberId, selectedCourseId]);
+
+  // All my scores for this course (flat array)
+  const allMyScores = useMemo(() => myRounds.flatMap((r) => r.scores), [myRounds]);
+
+  // Stats calculations
+  const myBasicStats = useMemo(
+    () => calculateCourseBasicStats(myRounds),
+    [myRounds]
+  );
+  const teamBasicStats = useMemo(
+    () => calculateCourseBasicStats(teamRounds),
+    [teamRounds]
+  );
+  const scoreDistribution = useMemo(
+    () => calculateScoreDistribution(allMyScores),
+    [allMyScores]
+  );
+  const holeScorePattern = useMemo(
+    () => calculateHoleScorePattern(allMyScores),
+    [allMyScores]
+  );
+
+  // Hole-specific calculations
+  const holeTendency = useMemo(
+    () => (selectedHole ? calculateTeeShotTendency(allMyScores, selectedHole) : null),
+    [allMyScores, selectedHole]
+  );
+  const holeApproachClubs = useMemo(
+    () => (selectedHole ? calculateApproachClubs(allMyScores, selectedHole) : []),
+    [allMyScores, selectedHole]
+  );
+  const holePinScores = useMemo(
+    () => (selectedHole ? calculatePinPositionScores(allMyScores, selectedHole) : []),
+    [allMyScores, selectedHole]
+  );
+
+  // Selected hole's par
+  const selectedHolePar = useMemo(() => {
+    if (!selectedHole) return null;
+    const score = allMyScores.find((s) => s.hole_number === selectedHole);
+    return score?.par ?? null;
+  }, [allMyScores, selectedHole]);
+
+  // Number of holes (might not be 18)
+  const holeCount = useMemo(() => {
+    if (allMyScores.length === 0) return 18;
+    return Math.max(...allMyScores.map((s) => s.hole_number));
+  }, [allMyScores]);
+
+  // Has shots_detail for selected hole
+  const hasDetailData = useMemo(() => {
+    if (!selectedHole) return false;
+    return allMyScores.some(
+      (s) => s.hole_number === selectedHole && s.shots_detail && s.shots_detail.length > 0
+    );
+  }, [allMyScores, selectedHole]);
+
+  // Has pin_position data for selected hole
+  const hasPinData = useMemo(() => {
+    if (!selectedHole) return false;
+    return allMyScores.some((s) => s.hole_number === selectedHole && s.pin_position);
+  }, [allMyScores, selectedHole]);
+
+  if (isLoadingCourses) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (courses.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-12 text-center text-muted-foreground">
+          まだプレイしたコースがありません。スコアを入力してください。
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Course selector */}
+      <Select value={selectedCourseId} onValueChange={setSelectedCourseId}>
+        <SelectTrigger className="w-full">
+          <SelectValue placeholder="コースを選択してください" />
+        </SelectTrigger>
+        <SelectContent>
+          {courses.map((c) => (
+            <SelectItem key={c.id} value={c.id}>
+              {c.name}
+              {c.pref ? ` (${c.pref})` : ""}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {!selectedCourseId && (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            コースを選択してください
+          </CardContent>
+        </Card>
+      )}
+
+      {isLoadingData && (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {selectedCourseId && !isLoadingData && myRounds.length > 0 && (
+        <>
+          {/* Basic stats cards */}
+          <div>
+            <h3 className="text-lg font-semibold mb-3">コース概要</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <StatCard
+                label="平均スコア"
+                value={myBasicStats.avgScore.toFixed(1)}
+                myStats={myBasicStats}
+                teamStats={teamBasicStats}
+                statKey="avgScore"
+              />
+              <StatCard
+                label="平均パット"
+                value={myBasicStats.avgPutts.toFixed(1)}
+                myStats={myBasicStats}
+                teamStats={teamBasicStats}
+                statKey="avgPutts"
+              />
+              <StatCard
+                label="GIR率"
+                value={`${myBasicStats.girRate.toFixed(1)}%`}
+                myStats={myBasicStats}
+                teamStats={teamBasicStats}
+                statKey="girRate"
+              />
+              <StatCard
+                label="FWキープ率"
+                value={`${myBasicStats.fairwayKeepRate.toFixed(1)}%`}
+                myStats={myBasicStats}
+                teamStats={teamBasicStats}
+                statKey="fairwayKeepRate"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground mt-2">
+              ラウンド数: 自分 {myBasicStats.roundCount}回 / チーム全体 {teamBasicStats.roundCount}回
+            </p>
+          </div>
+
+          {/* Score distribution pie chart */}
+          <Card>
+            <CardHeader>
+              <CardTitle>スコア分布</CardTitle>
+            </CardHeader>
+            <CardContent className="h-64">
+              {scoreDistribution.total > 0 ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <PieChart>
+                    <Pie
+                      data={[
+                        { name: "Eagle-", value: scoreDistribution.eagle, color: PIE_COLORS.eagle },
+                        { name: "Birdie", value: scoreDistribution.birdie, color: PIE_COLORS.birdie },
+                        { name: "Par", value: scoreDistribution.par, color: PIE_COLORS.par },
+                        { name: "Bogey", value: scoreDistribution.bogey, color: PIE_COLORS.bogey },
+                        { name: "Double+", value: scoreDistribution.doublePlus, color: PIE_COLORS.doublePlus },
+                      ].filter((d) => d.value > 0)}
+                      dataKey="value"
+                      nameKey="name"
+                      cx="50%"
+                      cy="50%"
+                      outerRadius={80}
+                      label={({ name, percent }) =>
+                        `${name} ${((percent ?? 0) * 100).toFixed(0)}%`
+                      }
+                    >
+                      {[
+                        { name: "Eagle-", value: scoreDistribution.eagle, color: PIE_COLORS.eagle },
+                        { name: "Birdie", value: scoreDistribution.birdie, color: PIE_COLORS.birdie },
+                        { name: "Par", value: scoreDistribution.par, color: PIE_COLORS.par },
+                        { name: "Bogey", value: scoreDistribution.bogey, color: PIE_COLORS.bogey },
+                        { name: "Double+", value: scoreDistribution.doublePlus, color: PIE_COLORS.doublePlus },
+                      ]
+                        .filter((d) => d.value > 0)
+                        .map((entry, index) => (
+                          <Cell key={`cell-${index}`} fill={entry.color} />
+                        ))}
+                    </Pie>
+                    <Tooltip />
+                  </PieChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  データが不足しています
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Hole score pattern line chart */}
+          <Card>
+            <CardHeader>
+              <CardTitle>ホール別スコアパターン</CardTitle>
+              <p className="text-xs text-muted-foreground">各ホールの平均オーバーパー</p>
+            </CardHeader>
+            <CardContent className="h-72">
+              {holeScorePattern.some((h) => h.count > 0) ? (
+                <ResponsiveContainer width="100%" height="100%">
+                  <LineChart data={holeScorePattern}>
+                    <CartesianGrid strokeDasharray="3 3" />
+                    <XAxis
+                      dataKey="hole"
+                      tick={{ fontSize: 12 }}
+                      label={{ value: "ホール", position: "insideBottomRight", offset: -5, fontSize: 11 }}
+                    />
+                    <YAxis
+                      tick={{ fontSize: 12 }}
+                      tickFormatter={(v: number) => (v > 0 ? `+${v}` : `${v}`)}
+                      label={{ value: "±パー", angle: -90, position: "insideLeft", fontSize: 11 }}
+                    />
+                    <Tooltip
+                      formatter={(value) => {
+                        const v = Number(value);
+                        return [(v > 0 ? "+" : "") + v.toFixed(2), "平均オーバーパー"];
+                      }}
+                      labelFormatter={(label) => `Hole ${label}`}
+                    />
+                    <ReferenceLine
+                      y={0}
+                      stroke="#888"
+                      strokeDasharray="3 3"
+                      label={{ value: "Par", position: "right", fontSize: 11 }}
+                    />
+                    <Line
+                      type="monotone"
+                      dataKey="avgOverPar"
+                      stroke="#22c55e"
+                      strokeWidth={2}
+                      dot={{ r: 3, fill: "#22c55e" }}
+                      activeDot={{ r: 5 }}
+                    />
+                  </LineChart>
+                </ResponsiveContainer>
+              ) : (
+                <div className="flex items-center justify-center h-full text-muted-foreground">
+                  データが不足しています
+                </div>
+              )}
+            </CardContent>
+          </Card>
+
+          {/* Hole detail analysis */}
+          <Card>
+            <CardHeader>
+              <CardTitle>ホール別詳細分析</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {/* Hole number buttons */}
+              <div className="flex gap-1.5 overflow-x-auto pb-2">
+                {Array.from({ length: holeCount }, (_, i) => i + 1).map((hole) => (
+                  <button
+                    key={hole}
+                    onClick={() => setSelectedHole(selectedHole === hole ? null : hole)}
+                    className={`flex-shrink-0 w-9 h-9 rounded-full text-sm font-medium transition-colors ${
+                      selectedHole === hole
+                        ? "bg-primary text-primary-foreground"
+                        : "bg-muted hover:bg-muted/80 text-foreground"
+                    }`}
+                  >
+                    {hole}
+                  </button>
+                ))}
+              </div>
+
+              {!selectedHole && (
+                <p className="text-center text-muted-foreground py-4">
+                  ホール番号を選択してください
+                </p>
+              )}
+
+              {selectedHole && (
+                <div className="space-y-4">
+                  <p className="text-sm text-muted-foreground">
+                    Hole {selectedHole} (Par {selectedHolePar ?? "?"})
+                  </p>
+
+                  {/* Tee shot tendency - only for Par 4+ */}
+                  {selectedHolePar && selectedHolePar >= 4 && holeTendency && (
+                    <div>
+                      <h4 className="text-sm font-medium mb-2">ティーショット傾向</h4>
+                      <TeeShotTendencyBar tendency={holeTendency} />
+                    </div>
+                  )}
+
+                  {/* Approach clubs */}
+                  {hasDetailData ? (
+                    <div>
+                      <h4 className="text-sm font-medium mb-2">アプローチ番手</h4>
+                      {holeApproachClubs.length > 0 ? (
+                        <div className="flex flex-wrap gap-2">
+                          {holeApproachClubs.map((c) => (
+                            <span
+                              key={c.club}
+                              className="inline-flex items-center gap-1 px-2.5 py-1 rounded-md bg-muted text-sm"
+                            >
+                              <span className="font-medium">{c.club}</span>
+                              <span className="text-muted-foreground">{c.count}回</span>
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground">アプローチデータなし</p>
+                      )}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-muted-foreground">
+                      詳細データなし（詳細スコア入力で記録してください）
+                    </p>
+                  )}
+
+                  {/* Pin position heatmap */}
+                  {hasPinData && (
+                    <div>
+                      <h4 className="text-sm font-medium mb-2">ピン位置別 平均スコア</h4>
+                      <PinPositionGrid pinScores={holePinScores} />
+                    </div>
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}
+
+function StatCard({
+  label,
+  value,
+  myStats,
+  teamStats,
+  statKey,
+}: {
+  label: string;
+  value: string;
+  myStats: CourseBasicStats;
+  teamStats: CourseBasicStats;
+  statKey: keyof CourseBasicStats;
+}) {
+  const myVal = myStats[statKey] as number;
+  const teamVal = teamStats[statKey] as number;
+  const diff = myVal - teamVal;
+  const isLowerBetter = statKey === "avgScore" || statKey === "avgPutts";
+  const isGood = isLowerBetter ? diff < 0 : diff > 0;
+
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="text-2xl font-bold">{value}</p>
+        {teamStats.roundCount > 0 && (
+          <p className={`text-xs mt-1 ${isGood ? "text-green-600" : "text-red-500"}`}>
+            vs チーム: {diff > 0 ? "+" : ""}
+            {statKey === "girRate" || statKey === "fairwayKeepRate"
+              ? diff.toFixed(1) + "%"
+              : diff.toFixed(1)}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function TeeShotTendencyBar({ tendency }: { tendency: { left: number; center: number; right: number } }) {
+  const total = tendency.left + tendency.center + tendency.right;
+  if (total === 0) {
+    return <p className="text-sm text-muted-foreground">データなし</p>;
+  }
+
+  const leftPct = (tendency.left / total) * 100;
+  const centerPct = (tendency.center / total) * 100;
+  const rightPct = (tendency.right / total) * 100;
+
+  return (
+    <div className="space-y-1">
+      <div className="flex h-6 rounded-md overflow-hidden">
+        {leftPct > 0 && (
+          <div
+            className="bg-red-400 flex items-center justify-center text-xs text-white"
+            style={{ width: `${leftPct}%` }}
+          >
+            {leftPct >= 15 && `${leftPct.toFixed(0)}%`}
+          </div>
+        )}
+        {centerPct > 0 && (
+          <div
+            className="bg-green-500 flex items-center justify-center text-xs text-white"
+            style={{ width: `${centerPct}%` }}
+          >
+            {centerPct >= 15 && `${centerPct.toFixed(0)}%`}
+          </div>
+        )}
+        {rightPct > 0 && (
+          <div
+            className="bg-blue-400 flex items-center justify-center text-xs text-white"
+            style={{ width: `${rightPct}%` }}
+          >
+            {rightPct >= 15 && `${rightPct.toFixed(0)}%`}
+          </div>
+        )}
+      </div>
+      <div className="flex justify-between text-xs text-muted-foreground">
+        <span>左 {tendency.left}回</span>
+        <span>中央 {tendency.center}回</span>
+        <span>右 {tendency.right}回</span>
+      </div>
+    </div>
+  );
+}
+
+function PinPositionGrid({ pinScores }: { pinScores: { position: string; avgOverPar: number; count: number }[] }) {
+  const scoreMap = new Map(pinScores.map((p) => [p.position, p]));
+
+  return (
+    <div className="grid grid-cols-3 gap-1 max-w-[200px]">
+      {PIN_POSITIONS.map((pos) => {
+        const data = scoreMap.get(pos.key);
+        const avgOverPar = data ? data.avgOverPar : null;
+        const colorClass = getPinColor(avgOverPar);
+
+        return (
+          <div
+            key={pos.key}
+            className={`aspect-square rounded flex flex-col items-center justify-center text-xs ${colorClass}`}
+          >
+            <span className="font-medium">{pos.label}</span>
+            {data && (
+              <span className="text-[10px]">
+                {avgOverPar! > 0 ? "+" : ""}
+                {avgOverPar!.toFixed(1)}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/utils/course-stats.ts
+++ b/src/utils/course-stats.ts
@@ -1,0 +1,245 @@
+import { Shot, TeeShot, ApproachShot } from "@/types/shot";
+import { PinPosition } from "@/types/database";
+
+// コース基本スタッツ
+export interface CourseBasicStats {
+  avgScore: number;
+  avgPutts: number;
+  girRate: number;
+  fairwayKeepRate: number;
+  roundCount: number;
+}
+
+// スコア分布
+export interface ScoreDistribution {
+  eagle: number;
+  birdie: number;
+  par: number;
+  bogey: number;
+  doublePlus: number;
+  total: number;
+}
+
+// ティーショット傾向
+export interface TeeShotTendency {
+  left: number;
+  center: number;
+  right: number;
+}
+
+// クラブ使用分布
+export interface ClubUsage {
+  club: string;
+  count: number;
+}
+
+// ピン位置別スコア
+export interface PinPositionScore {
+  position: string;
+  avgOverPar: number;
+  count: number;
+}
+
+// ホール別平均オーバーパー
+export interface HoleScorePattern {
+  hole: number;
+  avgOverPar: number;
+  count: number;
+}
+
+interface ScoreRow {
+  hole_number: number;
+  par: number;
+  score: number;
+  putts: number;
+  fairway_result: string;
+  pin_position: PinPosition | null;
+  shots_detail: unknown[] | null;
+}
+
+interface RoundScores {
+  scores: ScoreRow[];
+}
+
+/**
+ * shots_detail JSONBのType Guard付きパース
+ */
+export function parseShots(shotsDetail: unknown[] | null): Shot[] {
+  if (!shotsDetail || !Array.isArray(shotsDetail)) return [];
+
+  return shotsDetail.filter((item): item is Shot => {
+    if (typeof item !== "object" || item === null) return false;
+    const obj = item as Record<string, unknown>;
+    return obj.type === "tee" || obj.type === "approach" || obj.type === "putt";
+  });
+}
+
+/**
+ * コース固有の基本スタッツ算出（ラウンド単位で集計）
+ */
+export function calculateCourseBasicStats(rounds: RoundScores[]): CourseBasicStats {
+  if (rounds.length === 0) {
+    return { avgScore: 0, avgPutts: 0, girRate: 0, fairwayKeepRate: 0, roundCount: 0 };
+  }
+
+  let totalScore = 0;
+  let totalPutts = 0;
+  let totalHoles = 0;
+  let girCount = 0;
+  let fairwayKeepCount = 0;
+  let fairwayHoles = 0;
+
+  for (const round of rounds) {
+    for (const s of round.scores) {
+      totalScore += s.score;
+      totalPutts += s.putts;
+      totalHoles++;
+
+      const strokesBeforePutt = s.score - s.putts;
+      if (strokesBeforePutt <= s.par - 2) girCount++;
+
+      if (s.par >= 4) {
+        fairwayHoles++;
+        if (s.fairway_result === "keep") fairwayKeepCount++;
+      }
+    }
+  }
+
+  return {
+    avgScore: totalScore / rounds.length,
+    avgPutts: totalPutts / rounds.length,
+    girRate: totalHoles > 0 ? (girCount / totalHoles) * 100 : 0,
+    fairwayKeepRate: fairwayHoles > 0 ? (fairwayKeepCount / fairwayHoles) * 100 : 0,
+    roundCount: rounds.length,
+  };
+}
+
+/**
+ * スコア分布を計算（birdie/par/bogey/double+）
+ */
+export function calculateScoreDistribution(scores: ScoreRow[]): ScoreDistribution {
+  const dist: ScoreDistribution = {
+    eagle: 0,
+    birdie: 0,
+    par: 0,
+    bogey: 0,
+    doublePlus: 0,
+    total: scores.length,
+  };
+
+  for (const s of scores) {
+    const diff = s.score - s.par;
+    if (diff <= -2) dist.eagle++;
+    else if (diff === -1) dist.birdie++;
+    else if (diff === 0) dist.par++;
+    else if (diff === 1) dist.bogey++;
+    else dist.doublePlus++;
+  }
+
+  return dist;
+}
+
+/**
+ * ホール番号別の平均オーバーパー
+ */
+export function calculateHoleScorePattern(scores: ScoreRow[]): HoleScorePattern[] {
+  const grouped = new Map<number, { totalOverPar: number; count: number }>();
+
+  for (const s of scores) {
+    if (s.hole_number < 1 || s.hole_number > 18) continue;
+    const entry = grouped.get(s.hole_number) || { totalOverPar: 0, count: 0 };
+    entry.totalOverPar += s.score - s.par;
+    entry.count++;
+    grouped.set(s.hole_number, entry);
+  }
+
+  const maxHole = Math.max(...scores.map((s) => s.hole_number), 0);
+
+  return Array.from({ length: maxHole }, (_, i) => {
+    const hole = i + 1;
+    const entry = grouped.get(hole);
+    return {
+      hole,
+      avgOverPar: entry ? entry.totalOverPar / entry.count : 0,
+      count: entry?.count ?? 0,
+    };
+  });
+}
+
+/**
+ * ティーショット傾向（fairway_result: keep/left/right）。Par4+のみ対象
+ */
+export function calculateTeeShotTendency(scores: ScoreRow[], holeNumber: number): TeeShotTendency {
+  const holeScores = scores.filter((s) => s.hole_number === holeNumber && s.par >= 4);
+  const tendency: TeeShotTendency = { left: 0, center: 0, right: 0 };
+
+  for (const s of holeScores) {
+    if (s.fairway_result === "keep") tendency.center++;
+    else if (s.fairway_result === "left") tendency.left++;
+    else if (s.fairway_result === "right") tendency.right++;
+  }
+
+  return tendency;
+}
+
+/**
+ * アプローチ番手の集計。shots_detailからtype="approach"の最初のショットのclub集計
+ */
+export function calculateApproachClubs(scores: ScoreRow[], holeNumber: number): ClubUsage[] {
+  const holeScores = scores.filter((s) => s.hole_number === holeNumber);
+  const clubMap = new Map<string, number>();
+
+  for (const s of holeScores) {
+    const shots = parseShots(s.shots_detail);
+    const approach = shots.find((shot): shot is ApproachShot => shot.type === "approach");
+    if (approach) {
+      clubMap.set(approach.club, (clubMap.get(approach.club) || 0) + 1);
+    }
+  }
+
+  return Array.from(clubMap.entries())
+    .map(([club, count]) => ({ club, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/**
+ * ピン位置別の平均オーバーパー
+ */
+export function calculatePinPositionScores(scores: ScoreRow[], holeNumber: number): PinPositionScore[] {
+  const holeScores = scores.filter((s) => s.hole_number === holeNumber && s.pin_position);
+  const posMap = new Map<string, { totalOverPar: number; count: number }>();
+
+  for (const s of holeScores) {
+    if (!s.pin_position) continue;
+    const entry = posMap.get(s.pin_position) || { totalOverPar: 0, count: 0 };
+    entry.totalOverPar += s.score - s.par;
+    entry.count++;
+    posMap.set(s.pin_position, entry);
+  }
+
+  return Array.from(posMap.entries()).map(([position, data]) => ({
+    position,
+    avgOverPar: data.totalOverPar / data.count,
+    count: data.count,
+  }));
+}
+
+/**
+ * ティーショットのクラブ集計（shots_detailから）
+ */
+export function calculateTeeShotClubs(scores: ScoreRow[], holeNumber: number): ClubUsage[] {
+  const holeScores = scores.filter((s) => s.hole_number === holeNumber);
+  const clubMap = new Map<string, number>();
+
+  for (const s of holeScores) {
+    const shots = parseShots(s.shots_detail);
+    const teeShot = shots.find((shot): shot is TeeShot => shot.type === "tee");
+    if (teeShot) {
+      clubMap.set(teeShot.club, (clubMap.get(teeShot.club) || 0) + 1);
+    }
+  }
+
+  return Array.from(clubMap.entries())
+    .map(([club, count]) => ({ club, count }))
+    .sort((a, b) => b.count - a.count);
+}

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -78,6 +78,39 @@ export function calculateRadarData(
   ];
 }
 
+export interface HoleScoreTrend {
+  hole: number;
+  avgOverPar: number;
+  count: number;
+}
+
+/**
+ * ホール番号別の平均オーバーパー推移を計算
+ */
+export function calculateHoleScoreTrend(
+  scores: { hole_number: number; par: number; score: number }[]
+): HoleScoreTrend[] {
+  const grouped = new Map<number, { totalOverPar: number; count: number }>();
+
+  for (const s of scores) {
+    if (s.hole_number < 1 || s.hole_number > 18) continue;
+    const entry = grouped.get(s.hole_number) || { totalOverPar: 0, count: 0 };
+    entry.totalOverPar += s.score - s.par;
+    entry.count += 1;
+    grouped.set(s.hole_number, entry);
+  }
+
+  return Array.from({ length: 18 }, (_, i) => {
+    const hole = i + 1;
+    const entry = grouped.get(hole);
+    return {
+      hole,
+      avgOverPar: entry ? entry.totalOverPar / entry.count : 0,
+      count: entry?.count ?? 0,
+    };
+  });
+}
+
 export interface HoleAnalysis {
   parType: string;
   avgScore: number;


### PR DESCRIPTION
## Summary
- マイページに「総合分析」「コース詳細分析」の2つのタブを追加
- コース選択→コース概要（チーム比較付き）、スコア分布円グラフ、ホール別スコアパターン折れ線グラフを表示
- ホール別詳細分析（ティーショット傾向、アプローチ番手集計、ピン位置別ヒートマップ）を追加

## 変更ファイル
| ファイル | 操作 | 内容 |
|---------|------|------|
| `src/utils/course-stats.ts` | 新規 | コース分析用の集計関数群（7関数） |
| `src/components/course-analysis-tab.tsx` | 新規 | コース詳細分析タブコンポーネント |
| `src/app/my-stats/page.tsx` | 修正 | Tabs切り替え追加、ホール別スコア推移グラフ追加 |
| `src/utils/stats.ts` | 修正 | `calculateHoleScoreTrend` 関数追加 |

## Test plan
- [ ] マイページに「総合分析」「コース詳細分析」の2タブが表示される
- [ ] 「総合分析」タブで既存機能が壊れていない
- [ ] コース選択ドロップダウンにプレイ済みコースが表示される
- [ ] コース選択後、概要カード・スコア分布・ホール別パターンが表示される
- [ ] ホール番号選択でティーショット傾向・アプローチ番手・ピン位置別スコアが表示される
- [ ] `shots_detail`/`pin_position` がないデータでもクラッシュしない
- [ ] `npm run build` がエラーなく通る

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)