### PR TITLE
OCR入力UI微調整: トリプルボギー+3表記・ティー順・合計サマリー

### DIFF
--- a/src/app/input/page.tsx
+++ b/src/app/input/page.tsx
@@ -222,6 +222,12 @@ function InputContent() {
 
   const totalScore = scores.reduce((sum, s) => sum + s.score, 0);
   const totalPar = scores.reduce((sum, s) => sum + s.par, 0);
+  const totalPutts = scores.reduce((sum, s) => sum + s.putts, 0);
+  const totalOb = scores.reduce((sum, s) => sum + s.ob, 0);
+  const totalBunker = scores.reduce((sum, s) => sum + s.bunker, 0);
+  const totalPenalty = scores.reduce((sum, s) => sum + s.penalty, 0);
+  const fwKeepCount = scores.filter((s) => s.fairway_result === "keep").length;
+  const par4or5Count = scores.filter((s) => s.par >= 4).length;
 
   // 検索とグルーピング
   const groupedCourses = useMemo(() => {
@@ -452,11 +458,12 @@ function InputContent() {
                     onChange={(e) => setTeeColor(e.target.value)}
                     className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
                   >
+                    <option value="Black">Black</option>
                     <option value="Blue">Blue</option>
                     <option value="White">White</option>
-                    <option value="Red">Red</option>
+                    <option value="Green">Green</option>
                     <option value="Gold">Gold</option>
-                    <option value="Black">Black</option>
+                    <option value="Red">Red</option>
                   </select>
                 </div>
               </div>
@@ -474,6 +481,38 @@ function InputContent() {
               </CardTitle>
             </CardHeader>
             <CardContent>
+              <div className="grid grid-cols-3 sm:grid-cols-6 gap-2 mb-4 text-center text-sm">
+                <div className="rounded-lg bg-gray-50 p-2">
+                  <div className="text-muted-foreground text-xs">Putt</div>
+                  <div className="font-bold">{totalPutts}</div>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-2">
+                  <div className="text-muted-foreground text-xs">FW Keep</div>
+                  <div className="font-bold">
+                    {par4or5Count > 0 ? `${Math.round((fwKeepCount / par4or5Count) * 100)}%` : "-"}
+                  </div>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-2">
+                  <div className="text-muted-foreground text-xs">OB</div>
+                  <div className={cn("font-bold", totalOb > 0 && "text-red-600")}>{totalOb}</div>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-2">
+                  <div className="text-muted-foreground text-xs">Bunker</div>
+                  <div className={cn("font-bold", totalBunker > 0 && "text-orange-600")}>{totalBunker}</div>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-2">
+                  <div className="text-muted-foreground text-xs">Penalty</div>
+                  <div className={cn("font-bold", totalPenalty > 0 && "text-red-600")}>{totalPenalty}</div>
+                </div>
+                <div className="rounded-lg bg-gray-50 p-2">
+                  <div className="text-muted-foreground text-xs">Par3/4/5</div>
+                  <div className="font-bold">
+                    {scores.filter((s) => s.par === 3).length}/
+                    {scores.filter((s) => s.par === 4).length}/
+                    {scores.filter((s) => s.par === 5).length}
+                  </div>
+                </div>
+              </div>
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
                   <thead>

--- a/src/utils/golf-symbols.ts
+++ b/src/utils/golf-symbols.ts
@@ -42,7 +42,7 @@ export function getScoreSymbol(score: number, par: number): ScoreSymbolInfo {
     return { label: "D.Bogey", symbol: "□", color: "text-red-600", bgColor: "bg-red-100" };
   }
   if (diff === 3) {
-    return { label: "T.Bogey", symbol: "□□", color: "text-red-700", bgColor: "bg-red-200" };
+    return { label: "+3", symbol: "+3", color: "text-red-700", bgColor: "bg-red-200" };
   }
   return { label: `+${diff}`, symbol: `+${diff}`, color: "text-red-800", bgColor: "bg-red-300" };
 }


### PR DESCRIPTION
## Summary
- トリプルボギーのシンボルを □□ から +3 に変更（golf-symbols.ts）
- ティー選択の並び順を Black → Blue → White → Green → Gold → Red に変更（距離が長い順）
- スコア詳細テーブル上部に合計サマリーを追加（Putt合計、FWキープ率、OB/Bunker/Penalty合計、Par3/4/5内訳）

## Test plan
- [ ] `/input` でOCR結果確認時、トリプルボギーが+3で表示されることを確認
- [ ] ティー選択が Black, Blue, White, Green, Gold, Red の順に並んでいることを確認
- [ ] テーブル上部にPutt/FW Keep/OB/Bunker/Penalty/Par内訳の6項目サマリーが表示されることを確認
- [ ] スコア編集時にサマリーの値がリアルタイムで更新されることを確認
- [ ] `npm run build` でビルドエラーがないことを確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)