### PR TITLE
UI微調整: コースURL説明追加・スコア入力方法選択の改善

### DIFF
--- a/src/app/input/page.tsx
+++ b/src/app/input/page.tsx
@@ -16,7 +16,7 @@ import { Course, FairwayResult } from "@/types/database";
 import { cn } from "@/lib/utils";
 import { getScoreSymbol, getFairwaySymbol } from "@/utils/golf-symbols";
 
-type Step = "upload" | "processing" | "confirm";
+type Step = "select" | "upload" | "processing" | "confirm";
 
 export default function InputPage() {
   return (
@@ -29,7 +29,7 @@ export default function InputPage() {
 function InputContent() {
   const router = useRouter();
   const { member } = useAuth();
-  const [step, setStep] = useState<Step>("upload");
+  const [step, setStep] = useState<Step>("select");
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
   const [ocrResult, setOcrResult] = useState<OcrResult | null>(null);
@@ -265,41 +265,53 @@ function InputContent() {
       <h2 className="text-2xl font-bold">スコア入力</h2>
 
       {/* 入力方法の選択 */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <Card className="border-2 border-green-200 bg-green-50/50">
-          <CardContent className="p-4">
-            <div className="flex items-center gap-4">
-              <div className="p-3 rounded-full bg-green-100 shrink-0">
-                <Camera className="h-6 w-6 text-green-700" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <h3 className="font-semibold text-green-800">OCR自動入力</h3>
-                <p className="text-sm text-muted-foreground mt-1">
-                  スコアカードの写真から自動でスコアを読み取り
-                </p>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+      {(step === "select" || step === "upload") && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <Link href="/input/detailed">
+            <Card className="border-2 border-blue-200 bg-blue-50/50 hover:border-blue-400 transition-colors cursor-pointer h-full">
+              <CardContent className="p-4">
+                <div className="flex items-center gap-4">
+                  <div className="p-3 rounded-full bg-blue-100 shrink-0">
+                    <ClipboardEdit className="h-6 w-6 text-blue-700" />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-blue-800">詳細ショット入力</h3>
+                    <p className="text-xs text-blue-600 font-medium mt-0.5">推奨：超詳細なデータ分析がしたい人向け</p>
+                    <p className="text-sm text-muted-foreground mt-1">
+                      全ショットを手動で詳細に記録
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
 
-        <Link href="/input/detailed">
-          <Card className="border-2 border-blue-200 bg-blue-50/50 hover:border-blue-400 transition-colors cursor-pointer h-full">
+          <Card
+            className={cn(
+              "border-2 transition-colors cursor-pointer h-full",
+              step === "upload"
+                ? "border-green-500 bg-green-50"
+                : "border-green-200 bg-green-50/50 hover:border-green-400"
+            )}
+            onClick={() => setStep("upload")}
+          >
             <CardContent className="p-4">
               <div className="flex items-center gap-4">
-                <div className="p-3 rounded-full bg-blue-100 shrink-0">
-                  <ClipboardEdit className="h-6 w-6 text-blue-700" />
+                <div className="p-3 rounded-full bg-green-100 shrink-0">
+                  <Camera className="h-6 w-6 text-green-700" />
                 </div>
                 <div className="flex-1 min-w-0">
-                  <h3 className="font-semibold text-blue-800">詳細ショット入力</h3>
+                  <h3 className="font-semibold text-green-800">OCR自動入力</h3>
+                  <p className="text-xs text-green-600 font-medium mt-0.5">時間がない方向け</p>
                   <p className="text-sm text-muted-foreground mt-1">
-                    全ショットを手動で詳細に記録
+                    GDOスコアのスクショを載せると全ての情報を解析します
                   </p>
                 </div>
               </div>
             </CardContent>
           </Card>
-        </Link>
-      </div>
+        </div>
+      )}
 
       {step === "upload" && (
         <Card>
@@ -671,7 +683,7 @@ function InputContent() {
               variant="outline"
               className="flex-1"
               onClick={() => {
-                setStep("upload");
+                setStep("select");
                 setImageFile(null);
                 setImagePreview(null);
                 setOcrResult(null);

--- a/src/components/course/course-form.tsx
+++ b/src/components/course/course-form.tsx
@@ -338,7 +338,7 @@ export function CourseForm({ initialData, courseId }: CourseFormProps) {
             </Button>
           </div>
           <p className="text-xs text-muted-foreground mt-2">
-            ゴルフ場のコース紹介ページのURLを入力すると、コース情報を自動で取得します
+            ゴルフ場のコース紹介ページのURLを入力すると、コース情報を自動で取得します。GORAやGDO、公式ページのコース情報URLがおすすめです
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- コース編集画面のURL入力説明に「GORAやGDO、公式ページのコース情報URLがおすすめです」を追加
- スコア入力画面の入力方法カードの順序を変更（詳細ショット入力が上、OCR入力が下）
- OCR入力カードをクリックすると画像アップロード領域が表示されるように変更（初期表示では非表示）
- 詳細ショット入力に「推奨：超詳細なデータ分析がしたい人向け」、OCR入力に「時間がない方向け」「GDOスコアのスクショを載せると全ての情報を解析します」の説明を追加

## Test plan
- [ ] `/input` 初期表示で2つのカードのみ表示され、アップロード領域は非表示であることを確認
- [ ] 「詳細ショット入力」が上、「OCR入力」が下に表示されることを確認
- [ ] 各カードに説明文（推奨/時間がない方向け）が表示されていることを確認
- [ ] 「OCR入力」カードをクリックするとアップロード領域が表示されることを確認
- [ ] コース編集画面（`/admin/courses/[id]/edit`）のURL入力欄下にGORA/GDOの説明が表示されることを確認
- [ ] `npm run build` でビルドエラーがないことを確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)