### PR TITLE
feat: 管理者向け部員管理ページ + コース管理ナビ整理

### DIFF
--- a/src/app/admin/members/[id]/page.tsx
+++ b/src/app/admin/members/[id]/page.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import { RequireAdmin } from "@/components/auth/require-admin";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ClubSetEditor } from "@/components/club-set-editor";
+import { ArrowLeft, Save } from "lucide-react";
+import {
+  ClubType,
+  Gender,
+  MemberRole,
+  PreferredTee,
+} from "@/types/database";
+
+export default function AdminMemberDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const memberId = params.id as string;
+
+  const [name, setName] = useState("");
+  const [grade, setGrade] = useState<number>(1);
+  const [gender, setGender] = useState<Gender>("male");
+  const [role, setRole] = useState<MemberRole>("member");
+  const [preferredTee, setPreferredTee] = useState<PreferredTee>("white");
+  const [clubs, setClubs] = useState<ClubType[]>([]);
+
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  const fetchMember = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/admin/members/${memberId}`);
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "部員情報の取得に失敗しました");
+        return;
+      }
+      const m = data.member;
+      setName(m.name);
+      setGrade(m.grade);
+      setGender(m.gender || "male");
+      setRole(m.role);
+      setPreferredTee(m.preferred_tee || "white");
+      setClubs(m.clubs || []);
+    } catch {
+      setError("部員情報の取得に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [memberId]);
+
+  useEffect(() => {
+    fetchMember();
+  }, [fetchMember]);
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setSuccess("");
+    setIsSaving(true);
+
+    try {
+      const res = await fetch(`/api/admin/members/${memberId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name,
+          grade,
+          gender,
+          role,
+          preferred_tee: preferredTee,
+          clubs,
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "更新に失敗しました");
+        return;
+      }
+
+      setSuccess("保存しました");
+      setTimeout(() => setSuccess(""), 3000);
+    } catch {
+      setError("更新に失敗しました");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <RequireAdmin>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Link href="/admin/members">
+            <Button variant="ghost" size="icon">
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+          </Link>
+          <div>
+            <h2 className="text-2xl font-bold">部員編集</h2>
+            <p className="text-sm text-muted-foreground">
+              部員情報の確認・編集
+            </p>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <p className="text-muted-foreground text-center py-8">
+            読み込み中...
+          </p>
+        ) : error && !name ? (
+          <p className="text-destructive text-center py-8">{error}</p>
+        ) : (
+          <form onSubmit={handleSave} className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">基本情報</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="name">名前</Label>
+                  <Input
+                    id="name"
+                    type="text"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                  />
+                </div>
+
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="grade">学年</Label>
+                    <select
+                      id="grade"
+                      value={grade}
+                      onChange={(e) => setGrade(Number(e.target.value))}
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value={1}>1年</option>
+                      <option value={2}>2年</option>
+                      <option value={3}>3年</option>
+                      <option value={4}>4年</option>
+                      <option value={5}>5年（院1）</option>
+                      <option value={6}>6年（院2）</option>
+                    </select>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="gender">性別</Label>
+                    <select
+                      id="gender"
+                      value={gender}
+                      onChange={(e) => setGender(e.target.value as Gender)}
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                    >
+                      <option value="male">男性</option>
+                      <option value="female">女性</option>
+                      <option value="other">その他</option>
+                    </select>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="role">権限</Label>
+                  <select
+                    id="role"
+                    value={role}
+                    onChange={(e) => setRole(e.target.value as MemberRole)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                  >
+                    <option value="member">部員</option>
+                    <option value="admin">管理者</option>
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label>利用ティー</Label>
+                  <div className="flex gap-2">
+                    {[
+                      {
+                        value: "black",
+                        label: "黒",
+                        color: "bg-gray-800 text-white",
+                      },
+                      {
+                        value: "blue",
+                        label: "青",
+                        color: "bg-blue-500 text-white",
+                      },
+                      {
+                        value: "white",
+                        label: "白",
+                        color:
+                          "bg-white text-gray-800 border-2 border-gray-300",
+                      },
+                      {
+                        value: "red",
+                        label: "赤",
+                        color: "bg-red-500 text-white",
+                      },
+                      {
+                        value: "green",
+                        label: "緑",
+                        color: "bg-green-500 text-white",
+                      },
+                    ].map((tee) => (
+                      <button
+                        key={tee.value}
+                        type="button"
+                        onClick={() =>
+                          setPreferredTee(tee.value as PreferredTee)
+                        }
+                        className={`flex-1 py-2 rounded-lg font-medium text-sm transition-all ${tee.color} ${
+                          preferredTee === tee.value
+                            ? "ring-2 ring-offset-2 ring-primary"
+                            : "opacity-60 hover:opacity-100"
+                        }`}
+                      >
+                        {tee.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">クラブセット</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ClubSetEditor value={clubs} onChange={setClubs} />
+              </CardContent>
+            </Card>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            {success && (
+              <p className="text-sm text-green-600">{success}</p>
+            )}
+
+            <div className="flex gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.push("/admin/members")}
+              >
+                キャンセル
+              </Button>
+              <Button type="submit" disabled={isSaving}>
+                <Save className="h-4 w-4 mr-2" />
+                {isSaving ? "保存中..." : "保存する"}
+              </Button>
+            </div>
+          </form>
+        )}
+      </div>
+    </RequireAdmin>
+  );
+}

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -1,0 +1,221 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
+import { RequireAdmin } from "@/components/auth/require-admin";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, Pencil, Shield, ShieldOff, Trash2 } from "lucide-react";
+import { Member } from "@/types/database";
+
+type MemberWithCreatedAt = Member & { created_at: string };
+
+export default function AdminMembersPage() {
+  const [members, setMembers] = useState<MemberWithCreatedAt[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const fetchMembers = useCallback(async () => {
+    try {
+      const res = await fetch("/api/admin/members");
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error || "部員一覧の取得に失敗しました");
+        return;
+      }
+      setMembers(data.members);
+    } catch {
+      setError("部員一覧の取得に失敗しました");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchMembers();
+  }, [fetchMembers]);
+
+  const handleToggleRole = async (member: MemberWithCreatedAt) => {
+    const newRole = member.role === "admin" ? "member" : "admin";
+    const confirmMessage =
+      newRole === "admin"
+        ? `${member.name} を管理者に変更しますか？`
+        : `${member.name} の管理者権限を解除しますか？`;
+
+    if (!confirm(confirmMessage)) return;
+
+    try {
+      const res = await fetch(`/api/admin/members/${member.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role: newRole }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        alert(data.error || "権限の変更に失敗しました");
+        return;
+      }
+
+      setMembers((prev) =>
+        prev.map((m) => (m.id === member.id ? { ...m, role: newRole } : m))
+      );
+    } catch {
+      alert("権限の変更に失敗しました");
+    }
+  };
+
+  const handleDelete = async (member: MemberWithCreatedAt) => {
+    if (!confirm(`${member.name} を削除しますか？この操作は取り消せません。`))
+      return;
+
+    try {
+      const res = await fetch("/api/admin/members", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memberId: member.id }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        alert(data.error || "削除に失敗しました");
+        return;
+      }
+
+      setMembers((prev) => prev.filter((m) => m.id !== member.id));
+    } catch {
+      alert("削除に失敗しました");
+    }
+  };
+
+  const gradeLabel = (grade: number) => {
+    if (grade <= 4) return `${grade}年`;
+    if (grade === 5) return "院1";
+    return "院2";
+  };
+
+  return (
+    <RequireAdmin>
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <Link href="/admin">
+            <Button variant="ghost" size="icon">
+              <ArrowLeft className="h-5 w-5" />
+            </Button>
+          </Link>
+          <div>
+            <h2 className="text-2xl font-bold">部員管理</h2>
+            <p className="text-sm text-muted-foreground">
+              部員の一覧・権限管理・削除
+            </p>
+          </div>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">
+              部員一覧（{members.length}名）
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <p className="text-muted-foreground text-center py-8">
+                読み込み中...
+              </p>
+            ) : error ? (
+              <p className="text-destructive text-center py-8">{error}</p>
+            ) : members.length === 0 ? (
+              <p className="text-muted-foreground text-center py-8">
+                部員がいません
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>名前</TableHead>
+                      <TableHead className="w-[60px]">学年</TableHead>
+                      <TableHead className="w-[80px]">権限</TableHead>
+                      <TableHead className="w-[120px] text-right">
+                        操作
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {members.map((member) => (
+                      <TableRow key={member.id}>
+                        <TableCell>
+                          <Link
+                            href={`/admin/members/${member.id}`}
+                            className="text-primary hover:underline font-medium"
+                          >
+                            {member.name}
+                          </Link>
+                        </TableCell>
+                        <TableCell>{gradeLabel(member.grade)}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant={
+                              member.role === "admin"
+                                ? "default"
+                                : "secondary"
+                            }
+                          >
+                            {member.role === "admin" ? "管理者" : "部員"}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <div className="flex items-center justify-end gap-1">
+                            <Link href={`/admin/members/${member.id}`}>
+                              <Button variant="ghost" size="icon" title="編集">
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                            </Link>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title={
+                                member.role === "admin"
+                                  ? "管理者権限を解除"
+                                  : "管理者に変更"
+                              }
+                              onClick={() => handleToggleRole(member)}
+                            >
+                              {member.role === "admin" ? (
+                                <ShieldOff className="h-4 w-4" />
+                              ) : (
+                                <Shield className="h-4 w-4" />
+                              )}
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              title="削除"
+                              onClick={() => handleDelete(member)}
+                              className="text-destructive hover:text-destructive"
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </RequireAdmin>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,14 +9,19 @@ export default function AdminPage() {
       <p className="text-sm text-muted-foreground">部員・コースの管理</p>
 
       <div className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>部員管理</CardTitle>
-          </CardHeader>
-          <CardContent className="text-muted-foreground">
-            部員の追加・編集・削除
-          </CardContent>
-        </Card>
+        <Link href="/admin/members">
+          <Card className="hover:border-green-300 transition-colors cursor-pointer">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between">
+                部員管理
+                <ChevronRight className="w-5 h-5 text-muted-foreground" />
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="text-muted-foreground">
+              部員の一覧・権限管理・編集・削除
+            </CardContent>
+          </Card>
+        </Link>
 
         <Link href="/admin/courses">
           <Card className="hover:border-green-300 transition-colors cursor-pointer">

--- a/src/app/api/admin/members/[id]/route.ts
+++ b/src/app/api/admin/members/[id]/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+// GET: 特定部員の詳細情報を返す
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+
+    const { data: member, error } = await supabase
+      .from("members")
+      .select("id, name, grade, role, gender, preferred_tee, clubs, created_at")
+      .eq("id", id)
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { error: "部員が見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({ member });
+  } catch (error) {
+    console.error("Fetch member error:", error);
+    return NextResponse.json(
+      { error: "部員情報の取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+// PUT: 部員情報の更新
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const { name, grade, role, gender, preferred_tee, clubs } = body;
+
+    const updateData: Record<string, unknown> = {};
+
+    if (name !== undefined) {
+      if (typeof name !== "string" || !name.trim()) {
+        return NextResponse.json(
+          { error: "名前は必須です" },
+          { status: 400 }
+        );
+      }
+      updateData.name = name.trim();
+    }
+
+    if (grade !== undefined) {
+      if (typeof grade !== "number" || grade < 1 || grade > 6) {
+        return NextResponse.json(
+          { error: "学年は1〜6の値を指定してください" },
+          { status: 400 }
+        );
+      }
+      updateData.grade = grade;
+    }
+
+    if (role !== undefined) {
+      if (!["admin", "member"].includes(role)) {
+        return NextResponse.json(
+          { error: "Invalid role value" },
+          { status: 400 }
+        );
+      }
+      updateData.role = role;
+    }
+
+    if (gender !== undefined) {
+      if (!["male", "female", "other"].includes(gender)) {
+        return NextResponse.json(
+          { error: "Invalid gender value" },
+          { status: 400 }
+        );
+      }
+      updateData.gender = gender;
+    }
+
+    if (preferred_tee !== undefined) {
+      if (!["black", "blue", "white", "red", "green"].includes(preferred_tee)) {
+        return NextResponse.json(
+          { error: "Invalid preferred_tee value" },
+          { status: 400 }
+        );
+      }
+      updateData.preferred_tee = preferred_tee;
+    }
+
+    if (clubs !== undefined) {
+      if (!Array.isArray(clubs)) {
+        return NextResponse.json(
+          { error: "clubs must be an array" },
+          { status: 400 }
+        );
+      }
+      updateData.clubs = clubs;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        { error: "更新するフィールドがありません" },
+        { status: 400 }
+      );
+    }
+
+    const { data: member, error } = await supabase
+      .from("members")
+      .update(updateData)
+      .eq("id", id)
+      .select("id, name, grade, role, gender, preferred_tee, clubs")
+      .single();
+
+    if (error) {
+      console.error("Update member error:", error);
+      return NextResponse.json(
+        { error: "部員情報の更新に失敗しました" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ member });
+  } catch (error) {
+    console.error("Update member error:", error);
+    return NextResponse.json(
+      { error: "部員情報の更新に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/admin/members/route.ts
+++ b/src/app/api/admin/members/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+
+// GET: 全部員一覧を返す
+export async function GET() {
+  try {
+    const { data: members, error } = await supabase
+      .from("members")
+      .select("id, name, grade, role, gender, preferred_tee, clubs, created_at")
+      .order("grade", { ascending: true })
+      .order("name", { ascending: true });
+
+    if (error) {
+      console.error("Fetch members error:", error);
+      return NextResponse.json(
+        { error: "部員一覧の取得に失敗しました" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ members });
+  } catch (error) {
+    console.error("Fetch members error:", error);
+    return NextResponse.json(
+      { error: "部員一覧の取得に失敗しました" },
+      { status: 500 }
+    );
+  }
+}
+
+// DELETE: 部員を削除
+export async function DELETE(request: NextRequest) {
+  try {
+    const { memberId } = await request.json();
+
+    if (!memberId) {
+      return NextResponse.json(
+        { error: "memberId is required" },
+        { status: 400 }
+      );
+    }
+
+    const { error } = await supabase
+      .from("members")
+      .delete()
+      .eq("id", memberId);
+
+    if (error) {
+      console.error("Delete member error:", error);
+      return NextResponse.json(
+        { error: "部員の削除に失敗しました" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error("Delete member error:", error);
+    return NextResponse.json(
+      { error: "部員の削除に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/auth/require-admin.tsx
+++ b/src/components/auth/require-admin.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/contexts/auth-context";
+
+export function RequireAdmin({ children }: { children: React.ReactNode }) {
+  const { member, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && (!member || member.role !== "admin")) {
+      router.push("/");
+    }
+  }, [member, isLoading, router]);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[50vh]">
+        <p className="text-muted-foreground">読み込み中...</p>
+      </div>
+    );
+  }
+
+  if (!member || member.role !== "admin") {
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/layout/bottom-nav.tsx
+++ b/src/components/layout/bottom-nav.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BarChart3, Camera, Home, MapPin, User } from "lucide-react";
+import { BarChart3, Camera, Home, User } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
 
@@ -10,7 +10,6 @@ const navItems = [
   { href: "/", label: "ランキング", icon: Home },
   { href: "/input", label: "入力", icon: Camera },
   { href: "/my-stats", label: "マイ", icon: BarChart3 },
-  { href: "/admin/courses", label: "コース", icon: MapPin, adminOnly: true },
   { href: "/admin", label: "管理", icon: User, adminOnly: true, exact: true },
 ];
 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { BarChart3, Camera, Home, LogOut, MapPin, User } from "lucide-react";
+import { BarChart3, Camera, Home, LogOut, User } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/contexts/auth-context";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,6 @@ const navItems = [
   { href: "/", label: "ランキング", icon: Home },
   { href: "/input", label: "スコア入力", icon: Camera },
   { href: "/my-stats", label: "マイページ", icon: BarChart3 },
-  { href: "/admin/courses", label: "コース管理", icon: MapPin, adminOnly: true },
   { href: "/admin", label: "管理", icon: User, adminOnly: true, exact: true },
 ];
 

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}


### PR DESCRIPTION
## Summary
- 管理者向け部員管理機能を実装（一覧・詳細編集・権限変更・削除）
- `RequireAdmin` コンポーネントでadmin以外のアクセスをブロック
- サイドバー・下部ナビからコース管理タブを削除し、`/admin` 配下に整理

## 変更内容
| ファイル | 操作 |
|---|---|
| `src/components/auth/require-admin.tsx` | 新規: admin権限チェックコンポーネント |
| `src/app/api/admin/members/route.ts` | 新規: GET一覧 / DELETE削除 |
| `src/app/api/admin/members/[id]/route.ts` | 新規: GET詳細 / PUT更新 |
| `src/app/admin/members/page.tsx` | 新規: 部員一覧ページ |
| `src/app/admin/members/[id]/page.tsx` | 新規: 部員詳細・編集ページ |
| `src/components/ui/table.tsx` | 新規: shadcn Tableコンポーネント |
| `src/app/admin/page.tsx` | 修正: 部員管理カードにリンク追加 |
| `src/components/layout/sidebar.tsx` | 修正: コース管理タブ削除 |
| `src/components/layout/bottom-nav.tsx` | 修正: コース管理タブ削除 |

## Test plan
- [ ] `npm run build` でビルドエラーなし
- [ ] admin権限でログイン → `/admin` → 部員管理 → 一覧表示確認
- [ ] 部員名クリック → 詳細編集ページで情報更新できること
- [ ] 権限変更トグル（admin↔member）が動作すること
- [ ] 部員削除（confirm確認付き）が動作すること
- [ ] サイドバー・下部ナビからコース管理タブが消えていること
- [ ] `/admin` からコース管理に引き続きアクセスできること
- [ ] 非admin権限でアクセスすると `/` にリダイレクトされること

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)