### PR TITLE
feat: モバイル用ヘッダー追加

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { AuthProvider } from "@/contexts/auth-context";
 import { Sidebar } from "@/components/layout/sidebar";
 import { BottomNav } from "@/components/layout/bottom-nav";
+import { MobileHeader } from "@/components/layout/mobile-header";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -32,6 +33,7 @@ export default function RootLayout({
       >
         <AuthProvider>
           <Sidebar />
+          <MobileHeader />
           <main className="md:ml-60 min-h-screen pb-20 md:pb-0">
             <div className="container mx-auto px-4 py-6 max-w-5xl">
               {children}

--- a/src/components/layout/mobile-header.tsx
+++ b/src/components/layout/mobile-header.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { LogOut } from "lucide-react";
+import { useAuth } from "@/contexts/auth-context";
+import { Button } from "@/components/ui/button";
+
+export function MobileHeader() {
+  const router = useRouter();
+  const { member, logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    router.push("/login");
+  };
+
+  return (
+    <header className="md:hidden sticky top-0 z-50 bg-card border-b border-border">
+      <div className="flex items-center justify-between h-12 px-4">
+        <h1 className="text-base font-bold tracking-tight">Golf Dashboard</h1>
+        {member && (
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">
+              {member.grade}年 {member.name}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 text-muted-foreground"
+              onClick={handleLogout}
+            >
+              <LogOut className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- モバイル画面にアプリ名・ログインユーザー名・ログアウトボタンを表示するヘッダーを追加
- PC画面ではサイドバーに同情報があるため非表示（`md:hidden`）
- `sticky top-0` で画面上部に固定

## 変更内容
| ファイル | 操作 |
|---|---|
| `src/components/layout/mobile-header.tsx` | 新規: モバイル用ヘッダーコンポーネント |
| `src/app/layout.tsx` | 修正: MobileHeaderを組み込み |

## Test plan
- [ ] `npm run build` でビルドエラーなし
- [ ] モバイル幅でアプリ名「Golf Dashboard」が画面上部に表示されること
- [ ] モバイル幅でログイン中のユーザー名（学年＋名前）が表示されること
- [ ] ログアウトボタンが動作すること
- [ ] PC幅ではモバイルヘッダーが非表示であること
- [ ] スクロールしてもヘッダーが上部に固定されること

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)