### PR TITLE
feat: エラーバウンダリを追加 (#52)

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { AlertTriangle } from "lucide-react";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Unhandled error:", error);
+  }, [error]);
+
+  return (
+    <div className="flex items-center justify-center min-h-[50vh]">
+      <Card className="max-w-md w-full">
+        <CardContent className="py-12 text-center space-y-4">
+          <AlertTriangle className="h-12 w-12 text-yellow-500 mx-auto" />
+          <h2 className="text-xl font-bold">エラーが発生しました</h2>
+          <p className="text-sm text-muted-foreground">
+            予期しないエラーが発生しました。再試行してください。
+          </p>
+          <Button onClick={reset}>再試行</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error("Global error:", error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body
+        style={{
+          margin: 0,
+          fontFamily: "system-ui, sans-serif",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          minHeight: "100vh",
+          backgroundColor: "#f9fafb",
+        }}
+      >
+        <div style={{ textAlign: "center", padding: "2rem" }}>
+          <h2 style={{ fontSize: "1.25rem", fontWeight: "bold", marginBottom: "0.5rem" }}>
+            エラーが発生しました
+          </h2>
+          <p style={{ color: "#6b7280", marginBottom: "1rem" }}>
+            アプリケーションで問題が発生しました。
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: "0.5rem 1.5rem",
+              backgroundColor: "#16a34a",
+              color: "white",
+              border: "none",
+              borderRadius: "0.375rem",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+            }}
+          >
+            再試行
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
## Summary
- ルートレベルの `error.tsx` を追加: ページ内でのエラーをキャッチし、リトライボタン付きのUIを表示
- グローバルの `global-error.tsx` を追加: ルートレイアウト自体のエラーもキャッチする最終防御（インラインスタイルでShadcn/uiに依存しない）

## Test plan
- [ ] ページコンポーネントでエラーが発生した場合、error.tsx のUI（再試行ボタン付き）が表示されること
- [ ] 再試行ボタンをクリックすると正常に復帰すること
- [ ] レイアウトレベルのエラーでglobal-error.tsxが表示されること

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)