### PR TITLE
feat: 詳細スコア入力UX改善（部員フィードバック対応）

### DIFF
--- a/src/app/input/detailed/components/hole-navigation.tsx
+++ b/src/app/input/detailed/components/hole-navigation.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { HoleData } from "@/types/shot";
+import { getHoleScore } from "@/utils/shot-aggregation";
 import { getScoreSymbol } from "@/utils/golf-symbols";
 
 interface HoleNavigationProps {
@@ -18,7 +19,7 @@ export function HoleNavigation({
   return (
     <div className="flex items-center gap-1 px-2 py-2 overflow-x-auto">
       {holes.map((h) => {
-        const holeScore = h.shots.length;
+        const holeScore = getHoleScore(h);
         const scoreDiff = holeScore - h.par;
         const scoreSymbol = holeScore === 0 ? "" : getScoreSymbol(holeScore, h.par).symbol;
 

--- a/src/components/shot-input/putt-input.tsx
+++ b/src/components/shot-input/putt-input.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Star, Ruler, TrendingUp, MoveRight } from "lucide-react";
+import { Star, Ruler, TrendingUp, Check } from "lucide-react";
 
 interface PuttInputProps {
   shot: PuttShot;
@@ -32,8 +32,18 @@ const RATINGS = [1, 2, 3, 4, 5] as const;
 const DISTANCE_PRESETS = [1, 2, 3, 5, 7, 10];
 
 export function PuttInput({ shot, onChange, puttNumber }: PuttInputProps) {
+  const isOk = shot.note === "OK";
+
   // 8方向の結果からセンター（IN）かどうか判定
   const isIn = shot.result === "in";
+
+  const handleOkToggle = () => {
+    if (isOk) {
+      onChange({ ...shot, note: "" });
+    } else {
+      onChange({ ...shot, result: "in", distance: 1, note: "OK" });
+    }
+  };
 
   const handleResultChange = (direction: string) => {
     // direction-selectorからの値をPuttResultに変換
@@ -46,6 +56,26 @@ export function PuttInput({ shot, onChange, puttNumber }: PuttInputProps) {
 
   return (
     <div className="space-y-5">
+      {/* OKパットトグル */}
+      <button
+        type="button"
+        onClick={handleOkToggle}
+        className={cn(
+          "w-full flex items-center justify-center gap-2 py-2.5 rounded-xl font-medium transition-all",
+          isOk
+            ? "bg-purple-500 text-white shadow-md"
+            : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+        )}
+      >
+        <Check className="w-4 h-4" />
+        OKパット
+      </button>
+
+      {isOk ? (
+        <div className="text-center text-sm text-purple-600">
+          1m カップイン
+        </div>
+      ) : (<>
       {/* 距離 */}
       <div>
         <Label className="text-sm font-medium text-gray-700 flex items-center gap-2 mb-2">
@@ -205,6 +235,7 @@ export function PuttInput({ shot, onChange, puttNumber }: PuttInputProps) {
           className="h-16 resize-none"
         />
       </div>
+      </>)}
     </div>
   );
 }

--- a/src/components/shot-input/shot-result-selector.tsx
+++ b/src/components/shot-input/shot-result-selector.tsx
@@ -4,18 +4,19 @@ import { useState, useEffect } from "react";
 import { ShotResult } from "@/types/shot";
 import { DirectionSelector } from "./direction-selector";
 import { cn } from "@/lib/utils";
-import { Circle, CircleX, AlertTriangle, Target } from "lucide-react";
+import { Circle, CircleX, AlertTriangle, Target, MapPin } from "lucide-react";
 
 interface ShotResultSelectorProps {
   value: ShotResult;
   onChange: (value: ShotResult) => void;
 }
 
-type ResultCategory = "on" | "miss" | "ob" | "penalty";
+type ResultCategory = "on" | "miss" | "layup" | "ob" | "penalty";
 
 const CATEGORIES: { id: ResultCategory; label: string; icon: React.ReactNode; color: string }[] = [
   { id: "on", label: "グリーンON", icon: <Target className="w-5 h-5" />, color: "green" },
   { id: "miss", label: "外し", icon: <Circle className="w-5 h-5" />, color: "orange" },
+  { id: "layup", label: "レイアップ", icon: <MapPin className="w-5 h-5" />, color: "sky" },
   { id: "ob", label: "OB", icon: <CircleX className="w-5 h-5" />, color: "red" },
   { id: "penalty", label: "ペナルティ", icon: <AlertTriangle className="w-5 h-5" />, color: "yellow" },
 ];
@@ -24,6 +25,7 @@ const CATEGORIES: { id: ResultCategory; label: string; icon: React.ReactNode; co
 function getCategoryFromResult(result: ShotResult): ResultCategory {
   if (result.startsWith("on-")) return "on";
   if (result.startsWith("miss-")) return "miss";
+  if (result.startsWith("layup-")) return "layup";
   if (result.startsWith("ob-")) return "ob";
   if (result.startsWith("penalty-")) return "penalty";
   return "on";
@@ -43,6 +45,8 @@ export function ShotResultSelector({ value, onChange }: ShotResultSelectorProps)
       onChange("on-good" as ShotResult);
     } else if (newCategory === "miss") {
       onChange("miss-front" as ShotResult);
+    } else if (newCategory === "layup") {
+      onChange("layup-fairway");
     } else if (newCategory === "ob") {
       onChange("ob-left" as ShotResult);
     } else if (newCategory === "penalty") {
@@ -57,7 +61,7 @@ export function ShotResultSelector({ value, onChange }: ShotResultSelectorProps)
   return (
     <div className="space-y-4">
       {/* カテゴリ選択 */}
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-5 gap-1.5">
         {CATEGORIES.map((cat) => {
           const isSelected = category === cat.id;
           return (
@@ -66,12 +70,14 @@ export function ShotResultSelector({ value, onChange }: ShotResultSelectorProps)
               type="button"
               onClick={() => handleCategoryChange(cat.id)}
               className={cn(
-                "flex flex-col items-center justify-center p-3 rounded-xl transition-all",
+                "flex flex-col items-center justify-center p-2.5 rounded-xl transition-all",
                 isSelected
                   ? cat.color === "green"
                     ? "bg-green-500 text-white shadow-lg ring-2 ring-green-300"
                     : cat.color === "orange"
                     ? "bg-orange-500 text-white shadow-lg ring-2 ring-orange-300"
+                    : cat.color === "sky"
+                    ? "bg-sky-500 text-white shadow-lg ring-2 ring-sky-300"
                     : cat.color === "red"
                     ? "bg-red-500 text-white shadow-lg ring-2 ring-red-300"
                     : "bg-yellow-500 text-white shadow-lg ring-2 ring-yellow-300"
@@ -79,7 +85,7 @@ export function ShotResultSelector({ value, onChange }: ShotResultSelectorProps)
               )}
             >
               {cat.icon}
-              <span className="text-xs mt-1 font-medium">{cat.label}</span>
+              <span className="text-[10px] mt-1 font-medium leading-tight">{cat.label}</span>
             </button>
           );
         })}
@@ -98,6 +104,38 @@ export function ShotResultSelector({ value, onChange }: ShotResultSelectorProps)
             centerLabel={category === "on" ? "⛳OK" : ""}
             prefix={category}
           />
+        </div>
+      )}
+
+      {/* レイアップ方向 */}
+      {category === "layup" && (
+        <div className="p-4 bg-gray-50 rounded-xl">
+          <div className="text-center text-sm text-gray-600 mb-3">
+            レイアップ先
+          </div>
+          <div className="flex flex-wrap justify-center gap-2">
+            {([
+              { value: "layup-fairway", label: "FW" },
+              { value: "layup-rough-left", label: "ラフ左" },
+              { value: "layup-rough-right", label: "ラフ右" },
+              { value: "layup-bunker-left", label: "バンカー左" },
+              { value: "layup-bunker-right", label: "バンカー右" },
+            ] as const).map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => onChange(opt.value)}
+                className={cn(
+                  "px-4 py-2.5 rounded-xl font-medium transition-all",
+                  value === opt.value
+                    ? "bg-sky-500 text-white shadow-lg"
+                    : "bg-white text-gray-700 border-2 border-gray-200 hover:border-gray-400"
+                )}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/components/shot-input/tee-shot-input.tsx
+++ b/src/components/shot-input/tee-shot-input.tsx
@@ -5,16 +5,18 @@ import { ClubSelector } from "./club-selector";
 import { WindSelector } from "./wind-selector";
 import { DirectionSelector } from "./direction-selector";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { Target, TreePine, Waves, CircleX, AlertTriangle, Star } from "lucide-react";
+import { Target, TreePine, Waves, CircleX, AlertTriangle, Star, Ruler } from "lucide-react";
 
 interface TeeShotInputProps {
   shot: TeeShot;
   onChange: (shot: TeeShot) => void;
+  par?: number;
 }
 
-const TEE_RESULTS: { value: TeeResult; label: string; icon: React.ReactNode; color: string }[] = [
+const TEE_RESULTS_DEFAULT: { value: TeeResult; label: string; icon: React.ReactNode; color: string }[] = [
   { value: "fairway", label: "FW", icon: <Target className="w-4 h-4" />, color: "green" },
   { value: "rough", label: "ラフ", icon: <TreePine className="w-4 h-4" />, color: "yellow" },
   { value: "bunker", label: "バンカー", icon: <Waves className="w-4 h-4" />, color: "amber" },
@@ -22,11 +24,62 @@ const TEE_RESULTS: { value: TeeResult; label: string; icon: React.ReactNode; col
   { value: "penalty", label: "ペナ", icon: <AlertTriangle className="w-4 h-4" />, color: "orange" },
 ];
 
+const TEE_RESULTS_PAR3: { value: TeeResult; label: string; icon: React.ReactNode; color: string }[] = [
+  { value: "fairway", label: "ON", icon: <Target className="w-4 h-4" />, color: "green" },
+  { value: "rough", label: "外し", icon: <TreePine className="w-4 h-4" />, color: "yellow" },
+  { value: "bunker", label: "バンカー", icon: <Waves className="w-4 h-4" />, color: "amber" },
+  { value: "ob", label: "OB", icon: <CircleX className="w-4 h-4" />, color: "red" },
+  { value: "penalty", label: "ペナ", icon: <AlertTriangle className="w-4 h-4" />, color: "orange" },
+];
+
+// Par3用: よく使う距離のプリセット (yd)
+const TEE_DISTANCE_PRESETS = [80, 100, 120, 140, 160, 180];
+
 const RATINGS = [1, 2, 3, 4, 5] as const;
 
-export function TeeShotInput({ shot, onChange }: TeeShotInputProps) {
+export function TeeShotInput({ shot, onChange, par }: TeeShotInputProps) {
+  const isPar3 = par === 3;
+  const teeResults = isPar3 ? TEE_RESULTS_PAR3 : TEE_RESULTS_DEFAULT;
+
   return (
     <div className="space-y-5">
+      {/* Par3用: 距離入力 */}
+      {isPar3 && (
+        <div>
+          <Label className="text-sm font-medium text-gray-700 flex items-center gap-2 mb-2">
+            <Ruler className="w-4 h-4" /> 距離 (yd)
+          </Label>
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              value={shot.distance ?? 0}
+              onChange={(e) => onChange({ ...shot, distance: Number(e.target.value) || 0 })}
+              className="w-24 text-center text-lg font-bold"
+              min={0}
+              max={300}
+            />
+            <span className="text-gray-500">yd</span>
+          </div>
+          <div className="flex flex-wrap gap-2 mt-2">
+            {TEE_DISTANCE_PRESETS.map((dist) => (
+              <button
+                key={dist}
+                type="button"
+                onClick={() => onChange({ ...shot, distance: dist })}
+                className={cn(
+                  "px-3 py-1.5 rounded-lg text-sm font-medium transition-all",
+                  shot.distance === dist
+                    ? "bg-green-500 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                )}
+              >
+                {dist}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       {/* クラブ選択 */}
       <div>
         <Label className="text-sm font-medium text-gray-700 flex items-center gap-2 mb-2">
@@ -42,10 +95,10 @@ export function TeeShotInput({ shot, onChange }: TeeShotInputProps) {
       {/* 結果 */}
       <div>
         <Label className="text-sm font-medium text-gray-700 flex items-center gap-2 mb-2">
-          📍 着弾地点
+          📍 {isPar3 ? "結果" : "着弾地点"}
         </Label>
         <div className="grid grid-cols-5 gap-2">
-          {TEE_RESULTS.map((result) => (
+          {teeResults.map((result) => (
             <button
               key={result.value}
               type="button"

--- a/src/types/shot.ts
+++ b/src/types/shot.ts
@@ -77,6 +77,12 @@ export type ShotResult =
   | "miss-front-right"
   | "miss-back-left"
   | "miss-back-right"
+  // レイアップ
+  | "layup-fairway"
+  | "layup-rough-left"
+  | "layup-rough-right"
+  | "layup-bunker-left"
+  | "layup-bunker-right"
   // OB/ペナルティ
   | "ob-left"
   | "ob-right"
@@ -114,6 +120,7 @@ export interface TeeShot {
   result: TeeResult;
   resultDirection: LeftRight;
   wind: WindDirection;
+  distance?: number;  // Par3用: ティーショット距離 (yd)
   rating: Rating;
   note: string;
 }

--- a/src/utils/shot-aggregation.ts
+++ b/src/utils/shot-aggregation.ts
@@ -17,10 +17,17 @@ export interface AggregatedScore {
 }
 
 /**
+ * ホールのスコアを計算（ショット数 + OB罰打 + ペナルティ罰打）
+ */
+export function getHoleScore(hole: HoleData): number {
+  return hole.shots.length + countOB(hole) + countPenalty(hole);
+}
+
+/**
  * HoleData（ショット配列付き）を scores テーブルのフラットレコードに変換する
  */
 export function aggregateHoleData(hole: HoleData): AggregatedScore {
-  const score = hole.shots.length;
+  const score = getHoleScore(hole);
   const putts = hole.shots.filter((s) => s.type === "putt").length;
   const fairway_result = deriveFairwayResult(hole);
   const ob = countOB(hole);


### PR DESCRIPTION
## Summary
- 部員フィードバックを反映し、詳細スコア入力画面のUXを7点改善
- レイアップ選択肢追加、Par3距離入力、OB/ペナ罰打自動計算、OKパットトグル、カード並び替え、ヘッダー簡略化、全カード打数表示統一

## 変更内容
- **レイアップ**: `ShotResult`にlayup値5種追加、shot-result-selectorにカテゴリ追加
- **Par3距離**: `TeeShot`にdistanceフィールド追加、Par3時に距離入力UI+結果ラベル変更
- **罰打計算**: `getHoleScore()`ヘルパー追加、OB/ペナの罰打をスコア・表示打数に反映
- **OKパット**: putt-input内にOKトグル追加、ON時は詳細入力省略
- **並び替え**: 各カードヘッダーに上下矢印ボタン配置
- **ヘッダー**: Par・距離を読み取り専用テキストに変更
- **打数表示**: パットカードにも「X打目」を統一表示

## Test plan
- [ ] Par 5でアプローチ結果に「レイアップ」選択肢が表示される
- [ ] Par 3でティーショットに距離入力が表示され、ラベルがON/外しになる
- [ ] OBティーショット後の次ショットが「3打目」と表示される
- [ ] パットカード内でOKトグルON/OFFが切り替わる
- [ ] 上下ボタンでカード順序が入れ替わる
- [ ] ホールヘッダーのPar・距離が読み取り専用でコンパクト

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)