### PR TITLE
feat: 距離別スタッツを個人ランキング化

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,25 +5,20 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
 import { supabase } from "@/lib/supabase";
-import { MemberStats, DistanceBucket } from "@/types/database";
+import { MemberStats } from "@/types/database";
 import {
   calculateMemberStats,
-  calculateDetailedStats,
   getRankedStats,
   getStatValue,
   getCategoryDescription,
   RankingCategory,
-  DetailedRoundData,
 } from "@/utils/ranking";
 import { getRankableStatsByGroup } from "@/utils/stat-definitions";
-import { DistanceRateChart } from "@/components/distance-rate-chart";
 
 const rankableGroups = getRankableStatsByGroup();
 
 export default function DashboardPage() {
   const [stats, setStats] = useState<MemberStats[]>([]);
-  const [makePctByDistance, setMakePctByDistance] = useState<DistanceBucket[]>([]);
-  const [girByDistance, setGirByDistance] = useState<DistanceBucket[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [selectedGroup, setSelectedGroup] = useState(rankableGroups[0]?.group.key ?? "core");
 
@@ -66,22 +61,6 @@ export default function DashboardPage() {
 
       const calculatedStats = calculateMemberStats(roundData);
       setStats(calculatedStats);
-
-      // Calculate aggregate distance-based stats from all rounds
-      const allDetailedRounds: DetailedRoundData[] = roundData.map((r) => ({
-        member_id: r.member_id,
-        scores: r.scores.map((s) => ({
-          hole_number: s.hole_number,
-          par: s.par,
-          score: s.score,
-          putts: s.putts,
-          distance: s.distance,
-          shots_detail: s.shots_detail,
-        })),
-      }));
-      const aggregateDetailed = calculateDetailedStats(allDetailedRounds);
-      setMakePctByDistance(aggregateDetailed.make_pct_by_distance);
-      setGirByDistance(aggregateDetailed.gir_by_distance);
 
       setIsLoading(false);
     }
@@ -189,33 +168,6 @@ export default function DashboardPage() {
         </Tabs>
       )}
 
-      {/* Distance-based charts for shot group */}
-      {selectedGroup === "shot" && !isLoading && (makePctByDistance.length > 0 || girByDistance.length > 0) && (
-        <Card>
-          <CardHeader>
-            <CardTitle>距離別スタッツ（全体集計）</CardTitle>
-            <p className="text-sm text-muted-foreground">
-              詳細入力データがある全ラウンドの集計
-            </p>
-          </CardHeader>
-          <CardContent className="space-y-6">
-            {makePctByDistance.length > 0 && (
-              <DistanceRateChart
-                data={makePctByDistance}
-                title="距離別カップイン率"
-                color="#3b82f6"
-              />
-            )}
-            {girByDistance.length > 0 && (
-              <DistanceRateChart
-                data={girByDistance}
-                title="距離別パーオン率"
-                color="#22c55e"
-              />
-            )}
-          </CardContent>
-        </Card>
-      )}
     </div>
   );
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -149,6 +149,19 @@ export interface MemberStats {
   gir_from_rough: number;
   sand_save_rate: number | null;
   avg_driving_distance: number | null;
+  // パット距離別カップイン率 (requires shots_detail)
+  putt_make_1m: number | null;
+  putt_make_1_2m: number | null;
+  putt_make_2_5m: number | null;
+  putt_make_5_10m: number | null;
+  putt_make_10m_plus: number | null;
+  // 距離別パーオン率 (requires shots_detail)
+  gir_dist_100: number | null;
+  gir_dist_100_125: number | null;
+  gir_dist_125_150: number | null;
+  gir_dist_150_175: number | null;
+  gir_dist_175_200: number | null;
+  gir_dist_200_plus: number | null;
 }
 
 /** 距離帯別の成功率データ */

--- a/src/utils/stat-definitions.ts
+++ b/src/utils/stat-definitions.ts
@@ -1,5 +1,5 @@
 /** スタッツのグループ定義 */
-export type StatGroup = "core" | "scoring" | "putting" | "shot";
+export type StatGroup = "core" | "scoring" | "putting" | "shot" | "putt_distance" | "gir_distance";
 
 export interface StatGroupDef {
   key: StatGroup;
@@ -12,6 +12,8 @@ export const STAT_GROUPS: StatGroupDef[] = [
   { key: "scoring", label: "スコアリング", description: "スコア関連の詳細分析" },
   { key: "putting", label: "パッティング", description: "パット関連の詳細分析" },
   { key: "shot", label: "ショット", description: "ショット関連の詳細分析" },
+  { key: "putt_distance", label: "パット距離別", description: "距離別カップイン率" },
+  { key: "gir_distance", label: "パーオン距離別", description: "距離別パーオン率" },
 ];
 
 /** フォーマット種別 */
@@ -226,6 +228,120 @@ export const STAT_DEFINITIONS: StatDefinition[] = [
     description: "Par4でのティーショット推定飛距離",
     group: "shot",
     format: "score",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+
+  // Group E: パット距離別
+  {
+    key: "putt_make_1m",
+    label: "~1m",
+    description: "1m以内のカップイン率",
+    group: "putt_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "putt_make_1_2m",
+    label: "1-2m",
+    description: "1-2mのカップイン率",
+    group: "putt_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "putt_make_2_5m",
+    label: "2-5m",
+    description: "2-5mのカップイン率",
+    group: "putt_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "putt_make_5_10m",
+    label: "5-10m",
+    description: "5-10mのカップイン率",
+    group: "putt_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "putt_make_10m_plus",
+    label: "10m+",
+    description: "10m以上のカップイン率",
+    group: "putt_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+
+  // Group F: パーオン距離別
+  {
+    key: "gir_dist_100",
+    label: "~100yd",
+    description: "100yd以内からのパーオン率",
+    group: "gir_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "gir_dist_100_125",
+    label: "100-125yd",
+    description: "100-125ydからのパーオン率",
+    group: "gir_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "gir_dist_125_150",
+    label: "125-150yd",
+    description: "125-150ydからのパーオン率",
+    group: "gir_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "gir_dist_150_175",
+    label: "150-175yd",
+    description: "150-175ydからのパーオン率",
+    group: "gir_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "gir_dist_175_200",
+    label: "175-200yd",
+    description: "175-200ydからのパーオン率",
+    group: "gir_distance",
+    format: "percent",
+    lowerIsBetter: false,
+    requiresDetail: true,
+    rankable: true,
+  },
+  {
+    key: "gir_dist_200_plus",
+    label: "200yd+",
+    description: "200yd以上からのパーオン率",
+    group: "gir_distance",
+    format: "percent",
     lowerIsBetter: false,
     requiresDetail: true,
     rankable: true,


### PR DESCRIPTION
## Summary
- 距離別カップイン率・距離別パーオン率を全体集計グラフから**個人ランキング形式**に変更
- ランキングページに「パット距離別」「パーオン距離別」グループを追加し、各距離バケットごとにタブで部員をランキング表示
- パット距離バケットの単位を ft → m に修正（入力単位がメートルのため）

## 変更内容
- `MemberStats` に11個の距離別フィールド追加（パット5 + GIR6）
- `STAT_DEFINITIONS` に新グループ2つ & 定義11個追加
- `calculateMemberStats` 内で部員ごとに距離別スタッツを計算
- ランキングページから全体集計グラフ（`DistanceRateChart`）を削除

## Test plan
- [ ] ランキングページで「パット距離別」「パーオン距離別」グループが表示される
- [ ] 各距離バケットのタブで部員がランキング表示される
- [ ] `shots_detail` のない部員は表示されない
- [ ] my-stats ページの距離別チャートは引き続き動作する
- [ ] `npm run build` & `npm run lint` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)