### PR TITLE
fix: ハーフラウンド(9H)のスコア系スタッツを18H換算で正規化

### DIFF
--- a/src/app/input/detailed/page.tsx
+++ b/src/app/input/detailed/page.tsx
@@ -349,6 +349,14 @@ function DetailedInputContent() {
         courseId = existingCourse?.id ?? null;
       }
 
+      // サブコース名を解決（out/in）
+      const subCourseNames = roundData.subCourseIds.map((scId) => {
+        const sc = selectedCourse?.sub_courses.find((s) => s.id === scId);
+        return sc?.name ?? null;
+      });
+      const outCourseName = subCourseNames[0] ?? null;
+      const inCourseName = subCourseNames[1] ?? null;
+
       // rounds テーブルに insert
       const { data: round, error: roundError } = await supabase
         .from("rounds")
@@ -357,6 +365,8 @@ function DetailedInputContent() {
           course_id: courseId,
           date: roundData.date,
           tee_color: roundData.teeColor,
+          out_course_name: outCourseName,
+          in_course_name: inCourseName,
         })
         .select()
         .single();

--- a/src/utils/course-stats.ts
+++ b/src/utils/course-stats.ts
@@ -82,17 +82,20 @@ export function calculateCourseBasicStats(rounds: RoundScores[]): CourseBasicSta
     return { avgScore: 0, avgPutts: 0, girRate: 0, fairwayKeepRate: 0, roundCount: 0 };
   }
 
-  let totalScore = 0;
-  let totalPutts = 0;
+  let normalizedScoreSum = 0;
+  let normalizedPuttsSum = 0;
   let totalHoles = 0;
   let girCount = 0;
   let fairwayKeepCount = 0;
   let fairwayHoles = 0;
 
   for (const round of rounds) {
+    let roundScore = 0;
+    let roundPutts = 0;
+
     for (const s of round.scores) {
-      totalScore += s.score;
-      totalPutts += s.putts;
+      roundScore += s.score;
+      roundPutts += s.putts;
       totalHoles++;
 
       const strokesBeforePutt = s.score - s.putts;
@@ -103,11 +106,19 @@ export function calculateCourseBasicStats(rounds: RoundScores[]): CourseBasicSta
         if (s.fairway_result === "keep") fairwayKeepCount++;
       }
     }
+
+    // 18H換算で正規化
+    const holeCount = round.scores.length;
+    if (holeCount > 0) {
+      const factor = 18 / holeCount;
+      normalizedScoreSum += roundScore * factor;
+      normalizedPuttsSum += roundPutts * factor;
+    }
   }
 
   return {
-    avgScore: totalScore / rounds.length,
-    avgPutts: totalPutts / rounds.length,
+    avgScore: normalizedScoreSum / rounds.length,
+    avgPutts: normalizedPuttsSum / rounds.length,
     girRate: totalHoles > 0 ? (girCount / totalHoles) * 100 : 0,
     fairwayKeepRate: fairwayHoles > 0 ? (fairwayKeepCount / fairwayHoles) * 100 : 0,
     roundCount: rounds.length,

--- a/src/utils/ranking.ts
+++ b/src/utils/ranking.ts
@@ -43,13 +43,13 @@ export function calculateMemberStats(rounds: RoundData[]): MemberStats[] {
 
     if (roundCount === 0) continue;
 
-    let totalScore = 0;
-    let totalPutts = 0;
+    let normalizedScoreSum = 0;
+    let normalizedPuttsSum = 0;
+    let normalizedBirdieSum = 0;
     let totalHoles = 0;
     let girCount = 0;
     let fairwayKeepCount = 0;
     let fairwayHoles = 0; // Par 4, 5 only
-    let birdieCount = 0;
     let scrambleOpportunities = 0;
     let scrambleSuccess = 0;
 
@@ -95,10 +95,15 @@ export function calculateMemberStats(rounds: RoundData[]): MemberStats[] {
         (a, b) => a.hole_number - b.hole_number
       );
 
+      // Per-round accumulators for 18H normalization
+      let roundScore = 0;
+      let roundPutts = 0;
+      let roundBirdies = 0;
+
       for (let i = 0; i < sortedScores.length; i++) {
         const score = sortedScores[i];
-        totalScore += score.score;
-        totalPutts += score.putts;
+        roundScore += score.score;
+        roundPutts += score.putts;
         totalHoles++;
 
         // GIR: パーオン = (par - 2) 打以内でグリーンに乗った
@@ -116,7 +121,7 @@ export function calculateMemberStats(rounds: RoundData[]): MemberStats[] {
 
         // Birdie
         if (score.score < score.par) {
-          birdieCount++;
+          roundBirdies++;
         }
 
         // Scramble: パーオンしなかったがパー以上で上がった
@@ -237,19 +242,28 @@ export function calculateMemberStats(rounds: RoundData[]): MemberStats[] {
           }
         }
       }
+
+      // 18H換算で正規化（9Hラウンドを18H相当に補正）
+      const holeCount = sortedScores.length;
+      if (holeCount > 0) {
+        const factor = 18 / holeCount;
+        normalizedScoreSum += roundScore * factor;
+        normalizedPuttsSum += roundPutts * factor;
+        normalizedBirdieSum += roundBirdies * factor;
+      }
     }
 
     stats.push({
       member_id: memberId,
       member_name: data.name,
       round_count: roundCount,
-      // Core
-      avg_score: totalScore / roundCount,
-      avg_putts: totalPutts / roundCount,
+      // Core (18H換算で正規化済み)
+      avg_score: normalizedScoreSum / roundCount,
+      avg_putts: normalizedPuttsSum / roundCount,
       gir_rate: totalHoles > 0 ? (girCount / totalHoles) * 100 : 0,
       fairway_keep_rate:
         fairwayHoles > 0 ? (fairwayKeepCount / fairwayHoles) * 100 : 0,
-      avg_birdies: birdieCount / roundCount,
+      avg_birdies: normalizedBirdieSum / roundCount,
       scramble_rate:
         scrambleOpportunities > 0
           ? (scrambleSuccess / scrambleOpportunities) * 100


### PR DESCRIPTION
## Summary
- `avg_score` / `avg_putts` / `avg_birdies` を `totalScore / roundCount` からラウンドごとの18H換算正規化に変更
- `course-stats.ts` の `avgScore` / `avgPutts` も同様に修正
- 詳細入力フローで `out_course_name` / `in_course_name` が保存されない問題を修正

Closes #66

## 修正内容
9Hラウンドのスコア45を `45 × (18/9) = 90` として18H相当に換算してから平均を取る。
18Hラウンドは `× (18/18) = × 1.0` なので影響なし。

率系スタッツ（GIR率、FWキープ率等）はホール数ベースで計算されているため変更不要。

## Test plan
- [ ] 18Hラウンドのみの部員のスタッツが変わらないことを確認
- [ ] 9Hラウンドの部員の avg_score が18H相当で表示されることを確認
- [ ] コース別スタッツの avgScore / avgPutts も正規化されていること
- [ ] 詳細入力で保存したラウンドに out_course_name / in_course_name が入ること
- [ ] `npm run build` & `npm run lint` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)