### PR TITLE
feat: ラウンド詳細ページUI刷新 — ホールセレクター + 詳細カード (#68)

### DIFF
--- a/src/app/api/rounds/[id]/scores/route.ts
+++ b/src/app/api/rounds/[id]/scores/route.ts
@@ -1,0 +1,159 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabase } from "@/lib/supabase";
+import { requireAuth, isAuthError } from "@/lib/api-auth";
+
+// PATCH: 特定ホールのスコアデータを更新
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const auth = await requireAuth(request);
+  if (isAuthError(auth)) return auth;
+
+  try {
+    const { id: roundId } = await params;
+    const body = await request.json();
+    const { score_id, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail } = body;
+
+    if (!score_id || typeof score_id !== "string") {
+      return NextResponse.json(
+        { error: "score_id は必須です" },
+        { status: 400 }
+      );
+    }
+
+    // round_id の所有者チェック
+    const { data: round, error: roundError } = await supabase
+      .from("rounds")
+      .select("id, member_id")
+      .eq("id", roundId)
+      .single();
+
+    if (roundError || !round) {
+      return NextResponse.json(
+        { error: "ラウンドが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    if (round.member_id !== auth.id) {
+      return NextResponse.json(
+        { error: "このラウンドを編集する権限がありません" },
+        { status: 403 }
+      );
+    }
+
+    // score_id が round_id に紐づくか確認
+    const { data: existingScore, error: scoreError } = await supabase
+      .from("scores")
+      .select("id, round_id")
+      .eq("id", score_id)
+      .single();
+
+    if (scoreError || !existingScore) {
+      return NextResponse.json(
+        { error: "スコアが見つかりません" },
+        { status: 404 }
+      );
+    }
+
+    if (existingScore.round_id !== roundId) {
+      return NextResponse.json(
+        { error: "このスコアは指定されたラウンドに属していません" },
+        { status: 400 }
+      );
+    }
+
+    // 更新データを構築
+    const updateData: Record<string, unknown> = {};
+
+    if (score !== undefined) {
+      if (typeof score !== "number" || score < 1) {
+        return NextResponse.json(
+          { error: "スコアは1以上の数値を指定してください" },
+          { status: 400 }
+        );
+      }
+      updateData.score = score;
+    }
+
+    if (putts !== undefined) {
+      if (typeof putts !== "number" || putts < 0) {
+        return NextResponse.json(
+          { error: "パット数は0以上の数値を指定してください" },
+          { status: 400 }
+        );
+      }
+      updateData.putts = putts;
+    }
+
+    if (fairway_result !== undefined) {
+      if (!["keep", "left", "right"].includes(fairway_result)) {
+        return NextResponse.json(
+          { error: "無効なフェアウェイ結果です" },
+          { status: 400 }
+        );
+      }
+      updateData.fairway_result = fairway_result;
+    }
+
+    if (ob !== undefined) {
+      if (typeof ob !== "number" || ob < 0) {
+        return NextResponse.json({ error: "OB数は0以上です" }, { status: 400 });
+      }
+      updateData.ob = ob;
+    }
+
+    if (bunker !== undefined) {
+      if (typeof bunker !== "number" || bunker < 0) {
+        return NextResponse.json({ error: "バンカー数は0以上です" }, { status: 400 });
+      }
+      updateData.bunker = bunker;
+    }
+
+    if (penalty !== undefined) {
+      if (typeof penalty !== "number" || penalty < 0) {
+        return NextResponse.json({ error: "ペナルティ数は0以上です" }, { status: 400 });
+      }
+      updateData.penalty = penalty;
+    }
+
+    if (pin_position !== undefined) {
+      updateData.pin_position = pin_position;
+    }
+
+    if (shots_detail !== undefined) {
+      updateData.shots_detail = shots_detail;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        { error: "更新するフィールドがありません" },
+        { status: 400 }
+      );
+    }
+
+    const { data: updatedScore, error: updateError } = await supabase
+      .from("scores")
+      .update(updateData)
+      .eq("id", score_id)
+      .select()
+      .single();
+
+    if (updateError) {
+      console.error("Update score error:", updateError);
+      return NextResponse.json(
+        { error: "スコアの更新に失敗しました" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ score: updatedScore });
+  } catch (error) {
+    console.error("Update score error:", error);
+    return NextResponse.json(
+      { error: "スコアの更新に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/my-stats/rounds/[id]/page.tsx
+++ b/src/app/my-stats/rounds/[id]/page.tsx
@@ -3,17 +3,23 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Loader2 } from "lucide-react";
+import { ArrowLeft, Loader2, Pencil, Eye } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { RequireAuth } from "@/components/auth/require-auth";
 import { useAuth } from "@/contexts/auth-context";
 import { supabase } from "@/lib/supabase";
-import { Score } from "@/types/database";
+import { authFetch } from "@/lib/api-client";
+import { Score, FairwayResult } from "@/types/database";
+import { Shot } from "@/types/shot";
 import { calculateRoundSummary, formatRoundDate } from "@/utils/round-stats";
 import { RoundSummaryStats } from "@/components/round-history/round-summary-stats";
 import { ScorecardTable } from "@/components/round-history/scorecard-table";
 import { ScoreDistributionChart } from "@/components/round-history/score-distribution-chart";
+import { HoleSelector } from "@/components/round-history/hole-selector";
+import { HoleDetailCard } from "@/components/round-history/hole-detail-card";
+import { HoleEditForm } from "@/components/round-history/hole-edit-form";
 
 interface RoundDetail {
   id: string;
@@ -25,6 +31,42 @@ interface RoundDetail {
   in_course_name: string | null;
   courses: { id: string; name: string; pref: string | null } | null;
   scores: Score[];
+}
+
+async function fetchRoundData(roundId: string, memberId: string): Promise<RoundDetail> {
+  const { data, error: fetchError } = await supabase
+    .from("rounds")
+    .select(
+      `id, member_id, date, tee_color, weather, out_course_name, in_course_name,
+      courses(id, name, pref),
+      scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail)`
+    )
+    .eq("id", roundId)
+    .single();
+
+  if (fetchError) {
+    throw new Error("ラウンドデータの取得に失敗しました。");
+  }
+
+  if (!data) {
+    throw new Error("ラウンドが見つかりません。");
+  }
+
+  if (data.member_id !== memberId) {
+    throw new Error("このラウンドを閲覧する権限がありません。");
+  }
+
+  return {
+    id: data.id,
+    member_id: data.member_id,
+    date: data.date,
+    tee_color: data.tee_color,
+    weather: data.weather,
+    out_course_name: data.out_course_name,
+    in_course_name: data.in_course_name,
+    courses: data.courses as unknown as { id: string; name: string; pref: string | null } | null,
+    scores: (data.scores as unknown as Score[]) ?? [],
+  };
 }
 
 export default function RoundDetailPage() {
@@ -43,57 +85,70 @@ function RoundDetailContent() {
   const [round, setRound] = useState<RoundDetail | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [selectedHole, setSelectedHole] = useState(1);
 
   useEffect(() => {
     if (!member || !roundId) return;
 
-    async function fetchRound() {
-      const { data, error: fetchError } = await supabase
-        .from("rounds")
-        .select(
-          `id, member_id, date, tee_color, weather, out_course_name, in_course_name,
-          courses(id, name, pref),
-          scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail)`
-        )
-        .eq("id", roundId)
-        .single();
+    let cancelled = false;
 
-      if (fetchError) {
-        console.error("Failed to fetch round:", fetchError);
-        setError("ラウンドデータの取得に失敗しました。");
-        setIsLoading(false);
-        return;
-      }
-
-      if (!data) {
-        setError("ラウンドが見つかりません。");
-        setIsLoading(false);
-        return;
-      }
-
-      // Auth check: only allow viewing own rounds
-      if (data.member_id !== member!.id) {
-        setError("このラウンドを閲覧する権限がありません。");
-        setIsLoading(false);
-        return;
-      }
-
-      setRound({
-        id: data.id,
-        member_id: data.member_id,
-        date: data.date,
-        tee_color: data.tee_color,
-        weather: data.weather,
-        out_course_name: data.out_course_name,
-        in_course_name: data.in_course_name,
-        courses: data.courses as unknown as { id: string; name: string; pref: string | null } | null,
-        scores: (data.scores as unknown as Score[]) ?? [],
+    fetchRoundData(roundId, member.id)
+      .then((data) => {
+        if (!cancelled) {
+          setRound(data);
+          setIsLoading(false);
+          if (data.scores.length > 0) {
+            const first = [...data.scores].sort((a, b) => a.hole_number - b.hole_number)[0];
+            setSelectedHole(first.hole_number);
+          }
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          console.error("Failed to fetch round:", err);
+          setError(err.message);
+          setIsLoading(false);
+        }
       });
-      setIsLoading(false);
+
+    return () => { cancelled = true; };
+  }, [member, roundId]);
+
+  const refreshRound = async () => {
+    if (!member || !roundId) return;
+    try {
+      const data = await fetchRoundData(roundId, member.id);
+      setRound(data);
+    } catch (err) {
+      console.error("Failed to refresh round:", err);
+    }
+  };
+
+  const handleSaveHole = async (data: {
+    score_id: string;
+    score: number;
+    putts: number;
+    fairway_result: FairwayResult;
+    ob: number;
+    bunker: number;
+    penalty: number;
+    pin_position: string | null;
+    shots_detail: Shot[] | null;
+  }) => {
+    const res = await authFetch(`/api/rounds/${roundId}/scores`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+    });
+
+    if (!res.ok) {
+      const err = await res.json();
+      throw new Error(err.error || "保存に失敗しました");
     }
 
-    fetchRound();
-  }, [member, roundId]);
+    await refreshRound();
+  };
 
   if (isLoading) {
     return (
@@ -127,6 +182,7 @@ function RoundDetailContent() {
   const scores = round.scores;
   const summary = calculateRoundSummary(scores);
   const courseName = round.courses?.name ?? "不明なコース";
+  const selectedScore = scores.find((s) => s.hole_number === selectedHole);
 
   return (
     <div className="space-y-6">
@@ -140,28 +196,50 @@ function RoundDetailContent() {
       </Link>
 
       {/* Round meta info */}
-      <div>
-        <h2 className="text-xl font-bold">{courseName}</h2>
-        <div className="flex items-center gap-2 mt-1 flex-wrap">
-          <span className="text-sm text-muted-foreground">
-            {formatRoundDate(round.date)}
-          </span>
-          {round.tee_color && (
-            <Badge variant="outline" className="text-xs">
-              {round.tee_color}
-            </Badge>
-          )}
-          {round.weather && (
-            <Badge variant="outline" className="text-xs">
-              {round.weather}
-            </Badge>
-          )}
-          {round.out_course_name && round.in_course_name && (
-            <span className="text-xs text-muted-foreground">
-              {round.out_course_name} / {round.in_course_name}
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-xl font-bold">{courseName}</h2>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            <span className="text-sm text-muted-foreground">
+              {formatRoundDate(round.date)}
             </span>
-          )}
+            {round.tee_color && (
+              <Badge variant="outline" className="text-xs">
+                {round.tee_color}
+              </Badge>
+            )}
+            {round.weather && (
+              <Badge variant="outline" className="text-xs">
+                {round.weather}
+              </Badge>
+            )}
+            {round.out_course_name && round.in_course_name && (
+              <span className="text-xs text-muted-foreground">
+                {round.out_course_name} / {round.in_course_name}
+              </span>
+            )}
+          </div>
         </div>
+
+        {/* Edit toggle button */}
+        <Button
+          variant={isEditMode ? "default" : "outline"}
+          size="sm"
+          onClick={() => setIsEditMode((prev) => !prev)}
+          className={isEditMode ? "bg-green-600 hover:bg-green-700" : ""}
+        >
+          {isEditMode ? (
+            <>
+              <Eye className="w-4 h-4 mr-1" />
+              閲覧モード
+            </>
+          ) : (
+            <>
+              <Pencil className="w-4 h-4 mr-1" />
+              編集
+            </>
+          )}
+        </Button>
       </div>
 
       {/* Summary stats */}
@@ -174,6 +252,40 @@ function RoundDetailContent() {
         </CardHeader>
         <CardContent>
           <ScorecardTable scores={scores} />
+        </CardContent>
+      </Card>
+
+      {/* Hole selector + detail */}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            ホール詳細
+            {isEditMode && (
+              <Badge variant="secondary" className="ml-2 text-xs">
+                編集モード
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <HoleSelector
+            scores={scores}
+            selectedHole={selectedHole}
+            onSelect={setSelectedHole}
+          />
+
+          {selectedScore && (
+            isEditMode ? (
+              <HoleEditForm
+                key={selectedScore.id}
+                score={selectedScore}
+                onSave={handleSaveHole}
+                onCancel={() => setIsEditMode(false)}
+              />
+            ) : (
+              <HoleDetailCard score={selectedScore} />
+            )
+          )}
         </CardContent>
       </Card>
 

--- a/src/components/round-history/hole-detail-card.tsx
+++ b/src/components/round-history/hole-detail-card.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Score, FairwayResult } from "@/types/database";
+import { getScoreSymbol, getFairwaySymbol } from "@/utils/golf-symbols";
+import { ScoreDisplay } from "@/components/shot-input/score-display";
+import { ShotDetailView } from "@/components/round-history/shot-detail-view";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface HoleDetailCardProps {
+  score: Score;
+}
+
+export function HoleDetailCard({ score }: HoleDetailCardProps) {
+  const sym = getScoreSymbol(score.score, score.par);
+  const diff = score.score - score.par;
+  const diffText = diff > 0 ? `+${diff}` : diff === 0 ? "E" : `${diff}`;
+
+  const hasShotsDetail =
+    score.shots_detail != null &&
+    Array.isArray(score.shots_detail) &&
+    score.shots_detail.length > 0;
+
+  return (
+    <Card>
+      <CardContent className="pt-5 space-y-4">
+        {/* Header: Hole badge + Par + Distance + Score */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-green-600 text-white flex items-center justify-center font-bold text-lg">
+              {score.hole_number}
+            </div>
+            <div>
+              <div className="text-sm text-muted-foreground">
+                Par {score.par}
+                {score.distance && (
+                  <span className="ml-2">{score.distance}yd</span>
+                )}
+              </div>
+              <div className={`text-sm font-semibold ${sym.color}`}>
+                {sym.label} ({diffText})
+              </div>
+            </div>
+          </div>
+          <ScoreDisplay score={score.score} par={score.par} size="md" />
+        </div>
+
+        {/* Basic stats row */}
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
+          <StatItem label="スコア" value={`${score.score} (${diffText})`} />
+          <StatItem label="パット" value={`${score.putts}`} />
+          <StatItem
+            label="FW"
+            value={
+              score.par <= 3
+                ? "-"
+                : getFairwaySymbol(score.fairway_result as FairwayResult).symbol +
+                  " " +
+                  getFairwaySymbol(score.fairway_result as FairwayResult).label
+            }
+          />
+          <StatItem label="OB" value={`${score.ob}`} highlight={score.ob > 0} />
+          <StatItem label="バンカー" value={`${score.bunker}`} highlight={score.bunker > 0} />
+          <StatItem label="ペナルティ" value={`${score.penalty}`} highlight={score.penalty > 0} />
+        </div>
+
+        {/* Shot detail section */}
+        <div>
+          <h4 className="text-xs font-medium text-muted-foreground mb-2">ショット詳細</h4>
+          {hasShotsDetail ? (
+            <ShotDetailView shotsDetail={score.shots_detail} />
+          ) : (
+            <p className="text-sm text-muted-foreground py-4 text-center">
+              ショット詳細データがありません
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatItem({
+  label,
+  value,
+  highlight = false,
+}: {
+  label: string;
+  value: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="text-center py-2 rounded-md bg-muted/30">
+      <p className="text-[10px] text-muted-foreground">{label}</p>
+      <p className={`text-sm font-semibold ${highlight ? "text-red-600" : ""}`}>{value}</p>
+    </div>
+  );
+}

--- a/src/components/round-history/hole-edit-form.tsx
+++ b/src/components/round-history/hole-edit-form.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import { useState } from "react";
+import { Score, FairwayResult } from "@/types/database";
+import {
+  Shot,
+  ApproachShot,
+  PuttShot,
+  createDefaultTeeShot,
+  createDefaultApproachShot,
+  createDefaultPutt,
+  DEFAULT_OPTIONAL_FIELDS,
+} from "@/types/shot";
+import { parseShots } from "@/utils/course-stats";
+import { TeeShotInput } from "@/components/shot-input/tee-shot-input";
+import { ApproachShotInput } from "@/components/shot-input/approach-shot-input";
+import { PuttInput } from "@/components/shot-input/putt-input";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Flag,
+  Target,
+  Circle,
+  Trash2,
+  ArrowUp,
+  ArrowDown,
+  ChevronDown,
+  ChevronUp,
+  Save,
+  X,
+  Loader2,
+} from "lucide-react";
+
+interface HoleEditFormProps {
+  score: Score;
+  onSave: (data: {
+    score_id: string;
+    score: number;
+    putts: number;
+    fairway_result: FairwayResult;
+    ob: number;
+    bunker: number;
+    penalty: number;
+    pin_position: string | null;
+    shots_detail: Shot[] | null;
+  }) => Promise<void>;
+  onCancel: () => void;
+}
+
+const FW_OPTIONS: { value: FairwayResult; label: string }[] = [
+  { value: "keep", label: "キープ" },
+  { value: "left", label: "左" },
+  { value: "right", label: "右" },
+];
+
+function getShotSummary(shot: Shot): string {
+  if (shot.type === "tee") {
+    const resultLabels: Record<string, string> = {
+      fairway: "FW", rough: "ラフ", bunker: "バンカー", ob: "OB", penalty: "ペナ",
+    };
+    return `${shot.club} → ${resultLabels[shot.result] ?? shot.result}`;
+  }
+  if (shot.type === "approach") {
+    const cat = shot.result.startsWith("on-") ? "ON" : shot.result.startsWith("miss-") ? "外し" : shot.result;
+    return `${shot.club} ${shot.distance}yd → ${cat}`;
+  }
+  if (shot.note === "OK") return "OKパット";
+  const puttLabels: Record<string, string> = {
+    in: "IN", front: "ショート", back: "オーバー", left: "左", right: "右",
+  };
+  return `${shot.distance}m → ${puttLabels[shot.result] ?? shot.result}`;
+}
+
+export function HoleEditForm({ score, onSave, onCancel }: HoleEditFormProps) {
+  const [editScore, setEditScore] = useState(score.score);
+  const [editPutts, setEditPutts] = useState(score.putts);
+  const [editFW, setEditFW] = useState<FairwayResult>(score.fairway_result);
+  const [editOB, setEditOB] = useState(score.ob);
+  const [editBunker, setEditBunker] = useState(score.bunker);
+  const [editPenalty, setEditPenalty] = useState(score.penalty);
+  const [editPinPosition] = useState<string | null>(score.pin_position);
+  const [shots, setShots] = useState<Shot[]>(() => parseShots(score.shots_detail));
+  const [expandedShot, setExpandedShot] = useState<number | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const addShot = (type: "tee" | "approach" | "putt") => {
+    let newShot: Shot;
+    switch (type) {
+      case "tee": newShot = createDefaultTeeShot(); break;
+      case "approach": newShot = createDefaultApproachShot(); break;
+      case "putt": newShot = createDefaultPutt(); break;
+    }
+    setShots((prev) => [...prev, newShot]);
+    setExpandedShot(shots.length);
+  };
+
+  const updateShot = (index: number, shot: Shot) => {
+    setShots((prev) => {
+      const next = [...prev];
+      next[index] = shot;
+      return next;
+    });
+  };
+
+  const removeShot = (index: number) => {
+    setShots((prev) => prev.filter((_, i) => i !== index));
+    setExpandedShot(null);
+  };
+
+  const moveShot = (index: number, direction: "up" | "down") => {
+    const newIndex = direction === "up" ? index - 1 : index + 1;
+    if (newIndex < 0 || newIndex >= shots.length) return;
+    setShots((prev) => {
+      const next = [...prev];
+      [next[index], next[newIndex]] = [next[newIndex], next[index]];
+      return next;
+    });
+    setExpandedShot(newIndex);
+  };
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await onSave({
+        score_id: score.id,
+        score: editScore,
+        putts: editPutts,
+        fairway_result: editFW,
+        ob: editOB,
+        bunker: editBunker,
+        penalty: editPenalty,
+        pin_position: editPinPosition,
+        shots_detail: shots.length > 0 ? shots : null,
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  let approachNum = 0;
+  let puttNum = 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Basic info */}
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <Label className="text-xs">スコア</Label>
+          <Input
+            type="number"
+            min={1}
+            value={editScore}
+            onChange={(e) => setEditScore(Number(e.target.value))}
+            className="h-9"
+          />
+        </div>
+        <div>
+          <Label className="text-xs">パット</Label>
+          <Input
+            type="number"
+            min={0}
+            value={editPutts}
+            onChange={(e) => setEditPutts(Number(e.target.value))}
+            className="h-9"
+          />
+        </div>
+        <div>
+          <Label className="text-xs">FW結果</Label>
+          {score.par > 3 ? (
+            <div className="flex gap-1 mt-1">
+              {FW_OPTIONS.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => setEditFW(opt.value)}
+                  className={`flex-1 text-xs py-1.5 rounded border transition-colors ${
+                    editFW === opt.value
+                      ? "bg-green-600 text-white border-green-600"
+                      : "border-gray-300 hover:bg-gray-50"
+                  }`}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground mt-2">Par3: -</div>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-3">
+        <div>
+          <Label className="text-xs">OB</Label>
+          <Input
+            type="number"
+            min={0}
+            value={editOB}
+            onChange={(e) => setEditOB(Number(e.target.value))}
+            className="h-9"
+          />
+        </div>
+        <div>
+          <Label className="text-xs">バンカー</Label>
+          <Input
+            type="number"
+            min={0}
+            value={editBunker}
+            onChange={(e) => setEditBunker(Number(e.target.value))}
+            className="h-9"
+          />
+        </div>
+        <div>
+          <Label className="text-xs">ペナルティ</Label>
+          <Input
+            type="number"
+            min={0}
+            value={editPenalty}
+            onChange={(e) => setEditPenalty(Number(e.target.value))}
+            className="h-9"
+          />
+        </div>
+      </div>
+
+      {/* Shot add buttons */}
+      <div>
+        <Label className="text-xs mb-2 block">ショット詳細</Label>
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => addShot("tee")}
+            className="flex-1 text-green-700 border-green-300 bg-green-50"
+          >
+            <Flag className="w-3.5 h-3.5 mr-1" />
+            ティー
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => addShot("approach")}
+            className="flex-1 text-blue-700 border-blue-300 bg-blue-50"
+          >
+            <Target className="w-3.5 h-3.5 mr-1" />
+            ショット
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => addShot("putt")}
+            className="flex-1 text-purple-700 border-purple-300 bg-purple-50"
+          >
+            <Circle className="w-3.5 h-3.5 mr-1" />
+            パット
+          </Button>
+        </div>
+      </div>
+
+      {/* Shot list */}
+      {shots.length > 0 && (
+        <div className="space-y-2">
+          {shots.map((shot, index) => {
+            if (shot.type === "approach") approachNum++;
+            if (shot.type === "putt") puttNum++;
+
+            const isExpanded = expandedShot === index;
+            const icon = shot.type === "tee"
+              ? <Flag className="w-3.5 h-3.5 text-green-600 shrink-0" />
+              : shot.type === "approach"
+                ? <Target className="w-3.5 h-3.5 text-blue-600 shrink-0" />
+                : <Circle className="w-3.5 h-3.5 text-purple-600 shrink-0" />;
+
+            const borderColor = shot.type === "tee"
+              ? "border-green-200"
+              : shot.type === "approach"
+                ? "border-blue-200"
+                : "border-purple-200";
+
+            const bgColor = shot.type === "tee"
+              ? "bg-green-50"
+              : shot.type === "approach"
+                ? "bg-blue-50"
+                : "bg-purple-50";
+
+            return (
+              <Card key={index} className={`border ${borderColor} overflow-hidden`}>
+                <div
+                  className={`${bgColor} px-2 py-1.5 flex items-center justify-between cursor-pointer`}
+                  onClick={() => setExpandedShot(isExpanded ? null : index)}
+                >
+                  <div className="flex items-center gap-1.5 min-w-0">
+                    {isExpanded ? <ChevronUp className="w-3.5 h-3.5 text-gray-500 shrink-0" /> : <ChevronDown className="w-3.5 h-3.5 text-gray-500 shrink-0" />}
+                    {icon}
+                    <span className="text-xs font-medium truncate">
+                      {index + 1}. {getShotSummary(shot)}
+                    </span>
+                  </div>
+                  {isExpanded && (
+                    <div className="flex items-center gap-0.5 shrink-0">
+                      <button type="button" onClick={(e) => { e.stopPropagation(); moveShot(index, "up"); }} disabled={index === 0} className="p-0.5 text-gray-500 hover:bg-white/50 rounded disabled:opacity-30"><ArrowUp className="w-3.5 h-3.5" /></button>
+                      <button type="button" onClick={(e) => { e.stopPropagation(); moveShot(index, "down"); }} disabled={index === shots.length - 1} className="p-0.5 text-gray-500 hover:bg-white/50 rounded disabled:opacity-30"><ArrowDown className="w-3.5 h-3.5" /></button>
+                      <button type="button" onClick={(e) => { e.stopPropagation(); removeShot(index); }} className="p-0.5 text-red-500 hover:bg-red-50 rounded"><Trash2 className="w-3.5 h-3.5" /></button>
+                    </div>
+                  )}
+                </div>
+                {isExpanded && (
+                  <CardContent className="p-3">
+                    {shot.type === "tee" && (
+                      <TeeShotInput
+                        shot={shot}
+                        onChange={(s) => updateShot(index, s)}
+                        par={score.par}
+                        optionalFields={DEFAULT_OPTIONAL_FIELDS}
+                      />
+                    )}
+                    {shot.type === "approach" && (
+                      <ApproachShotInput
+                        shot={shot as ApproachShot}
+                        onChange={(s) => updateShot(index, s)}
+                        shotNumber={approachNum}
+                        optionalFields={DEFAULT_OPTIONAL_FIELDS}
+                      />
+                    )}
+                    {shot.type === "putt" && (
+                      <PuttInput
+                        shot={shot as PuttShot}
+                        onChange={(s) => updateShot(index, s)}
+                        puttNumber={puttNum}
+                        optionalFields={DEFAULT_OPTIONAL_FIELDS}
+                      />
+                    )}
+                  </CardContent>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Save / Cancel */}
+      <div className="flex gap-2 pt-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onCancel}
+          className="flex-1"
+          disabled={isSaving}
+        >
+          <X className="w-4 h-4 mr-1" />
+          キャンセル
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={handleSave}
+          className="flex-1 bg-green-600 hover:bg-green-700"
+          disabled={isSaving}
+        >
+          {isSaving ? (
+            <Loader2 className="w-4 h-4 mr-1 animate-spin" />
+          ) : (
+            <Save className="w-4 h-4 mr-1" />
+          )}
+          {isSaving ? "保存中..." : "保存"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/round-history/hole-selector.tsx
+++ b/src/components/round-history/hole-selector.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { Score } from "@/types/database";
+import { getScoreSymbol } from "@/utils/golf-symbols";
+
+interface HoleSelectorProps {
+  scores: Score[];
+  selectedHole: number;
+  onSelect: (holeNumber: number) => void;
+}
+
+export function HoleSelector({ scores, selectedHole, onSelect }: HoleSelectorProps) {
+  const sorted = [...scores].sort((a, b) => a.hole_number - b.hole_number);
+
+  return (
+    <div className="flex items-center gap-1 px-2 py-2 overflow-x-auto">
+      {sorted.map((s) => {
+        const diff = s.score - s.par;
+        const symbol = getScoreSymbol(s.score, s.par).symbol;
+        const isSelected = selectedHole === s.hole_number;
+
+        return (
+          <button
+            key={s.hole_number}
+            onClick={() => onSelect(s.hole_number)}
+            className={cn(
+              "flex-shrink-0 min-w-[2.5rem] h-10 px-1 rounded-lg text-xs font-medium transition-all flex flex-col items-center justify-center",
+              isSelected
+                ? "bg-green-600 text-white shadow-md"
+                : diff < 0
+                  ? "bg-blue-100 text-blue-700"
+                  : diff === 0
+                    ? "bg-green-100 text-green-700"
+                    : "bg-orange-100 text-orange-700"
+            )}
+          >
+            <span>{s.hole_number}</span>
+            <span className="text-[10px] leading-none">{symbol}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/round-history/shot-detail-view.tsx
+++ b/src/components/round-history/shot-detail-view.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { parseShots } from "@/utils/course-stats";
+import { Shot, TeeShot, ApproachShot, PuttShot } from "@/types/shot";
+import { Flag, Target, Circle, Star } from "lucide-react";
+
+interface ShotDetailViewProps {
+  shotsDetail: unknown[] | null;
+}
+
+const teeResultLabels: Record<string, string> = {
+  fairway: "フェアウェイ",
+  rough: "ラフ",
+  bunker: "バンカー",
+  ob: "OB",
+  penalty: "ペナルティ",
+};
+
+const dirLabels: Record<string, string> = {
+  left: "左",
+  center: "中央",
+  right: "右",
+};
+
+const lieLabels: Record<string, string> = {
+  fairway: "フェアウェイ",
+  "left-rough": "左ラフ",
+  "right-rough": "右ラフ",
+  "left-bunker": "左バンカー",
+  "right-bunker": "右バンカー",
+};
+
+const slopeLabels: Record<string, string> = {
+  flat: "フラット",
+  uphill: "上り",
+  downhill: "下り",
+  left: "左傾斜",
+  right: "右傾斜",
+};
+
+function getApproachResultLabel(result: string): string {
+  if (result.startsWith("on-")) {
+    const dir = result.replace("on-", "");
+    const onDirLabels: Record<string, string> = {
+      center: "ピン付近",
+      front: "手前",
+      back: "奥",
+      left: "左",
+      right: "右",
+      "front-left": "手前左",
+      "front-right": "手前右",
+      "back-left": "奥左",
+      "back-right": "奥右",
+    };
+    return `グリーンON（${onDirLabels[dir] ?? dir}）`;
+  }
+  if (result.startsWith("miss-")) {
+    const dir = result.replace("miss-", "");
+    const missDirLabels: Record<string, string> = {
+      front: "手前",
+      back: "奥",
+      left: "左",
+      right: "右",
+      "front-left": "手前左",
+      "front-right": "手前右",
+      "back-left": "奥左",
+      "back-right": "奥右",
+    };
+    return `外し（${missDirLabels[dir] ?? dir}）`;
+  }
+  if (result.startsWith("layup-")) return "レイアップ";
+  if (result.startsWith("ob-")) return "OB";
+  if (result.startsWith("penalty-")) return "ペナルティ";
+  return result;
+}
+
+const puttResultLabels: Record<string, string> = {
+  in: "カップイン",
+  front: "ショート",
+  back: "オーバー",
+  left: "左",
+  right: "右",
+  "front-left": "ショート左",
+  "front-right": "ショート右",
+  "back-left": "オーバー左",
+  "back-right": "オーバー右",
+};
+
+const puttSlopeLabels: Record<string, string> = {
+  flat: "フラット",
+  uphill: "上り",
+  downhill: "下り",
+};
+
+const puttBreakLabels: Record<string, string> = {
+  straight: "ストレート",
+  slice: "スライス",
+  hook: "フック",
+};
+
+function RatingStars({ rating }: { rating: number }) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {[1, 2, 3, 4, 5].map((v) => (
+        <Star
+          key={v}
+          className={`w-3 h-3 ${v <= rating ? "fill-yellow-400 text-yellow-400" : "text-gray-300"}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+function getDisplayShotNumber(shots: Shot[], index: number): number {
+  let penalties = 0;
+  for (let i = 0; i < index; i++) {
+    const s = shots[i];
+    if (s.type === "tee" && (s.result === "ob" || s.result === "penalty")) {
+      penalties++;
+    } else if (s.type === "approach") {
+      const r = s.result;
+      if (r === "ob-left" || r === "ob-right" || r === "penalty-left" || r === "penalty-right") {
+        penalties++;
+      }
+    }
+  }
+  return index + 1 + penalties;
+}
+
+function TeeShotDetail({ shot }: { shot: TeeShot }) {
+  return (
+    <div className="space-y-1 text-sm">
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        <span>クラブ: <strong>{shot.club}</strong></span>
+        <span>結果: <strong>{teeResultLabels[shot.result] ?? shot.result}</strong></span>
+        {shot.result !== "ob" && shot.result !== "penalty" && (
+          <span>方向: <strong>{dirLabels[shot.resultDirection] ?? shot.resultDirection}</strong></span>
+        )}
+        {shot.distance && <span>距離: <strong>{shot.distance}yd</strong></span>}
+      </div>
+      <div className="flex items-center gap-3">
+        <RatingStars rating={shot.rating} />
+        {shot.note && <span className="text-xs text-muted-foreground">{shot.note}</span>}
+      </div>
+    </div>
+  );
+}
+
+function ApproachShotDetail({ shot }: { shot: ApproachShot }) {
+  return (
+    <div className="space-y-1 text-sm">
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        <span>クラブ: <strong>{shot.club}</strong></span>
+        <span>残り: <strong>{shot.distance}yd</strong></span>
+        <span>ライ: <strong>{lieLabels[shot.lie] ?? shot.lie}</strong></span>
+      </div>
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        <span>結果: <strong>{getApproachResultLabel(shot.result)}</strong></span>
+        {shot.slope !== "flat" && (
+          <span>傾斜: <strong>{slopeLabels[shot.slope] ?? shot.slope}</strong></span>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        <RatingStars rating={shot.rating} />
+        {shot.note && <span className="text-xs text-muted-foreground">{shot.note}</span>}
+      </div>
+    </div>
+  );
+}
+
+function PuttShotDetail({ shot }: { shot: PuttShot }) {
+  const isOkPutt = shot.note === "OK";
+  if (isOkPutt) {
+    return (
+      <div className="text-sm">
+        <span className="font-medium text-purple-700">OKパット</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-1 text-sm">
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        <span>距離: <strong>{shot.distance}m</strong></span>
+        <span>結果: <strong>{puttResultLabels[shot.result] ?? shot.result}</strong></span>
+        {shot.slope !== "flat" && (
+          <span>傾斜: <strong>{puttSlopeLabels[shot.slope] ?? shot.slope}</strong></span>
+        )}
+        {shot.break !== "straight" && (
+          <span>曲がり: <strong>{puttBreakLabels[shot.break] ?? shot.break}</strong></span>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        <RatingStars rating={shot.rating} />
+        {shot.note && <span className="text-xs text-muted-foreground">{shot.note}</span>}
+      </div>
+    </div>
+  );
+}
+
+export function ShotDetailView({ shotsDetail }: ShotDetailViewProps) {
+  const shots = parseShots(shotsDetail);
+
+  if (shots.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground py-2">
+        ショット詳細データがありません
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {shots.map((shot, index) => {
+        const shotNum = getDisplayShotNumber(shots, index);
+        const icon =
+          shot.type === "tee" ? (
+            <Flag className="w-3.5 h-3.5 text-green-600 shrink-0" />
+          ) : shot.type === "approach" ? (
+            <Target className="w-3.5 h-3.5 text-blue-600 shrink-0" />
+          ) : (
+            <Circle className="w-3.5 h-3.5 text-purple-600 shrink-0" />
+          );
+
+        const typeLabel =
+          shot.type === "tee"
+            ? "ティー"
+            : shot.type === "approach"
+              ? "ショット"
+              : "パット";
+
+        const borderColor =
+          shot.type === "tee"
+            ? "border-l-green-400"
+            : shot.type === "approach"
+              ? "border-l-blue-400"
+              : "border-l-purple-400";
+
+        return (
+          <div
+            key={index}
+            className={`border-l-2 ${borderColor} pl-3 py-1`}
+          >
+            <div className="flex items-center gap-1.5 mb-1">
+              {icon}
+              <span className="text-xs font-medium text-muted-foreground">
+                {shotNum}打目 - {typeLabel}
+              </span>
+            </div>
+            {shot.type === "tee" && <TeeShotDetail shot={shot} />}
+            {shot.type === "approach" && <ApproachShotDetail shot={shot} />}
+            {shot.type === "putt" && <PuttShotDetail shot={shot} />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/utils/golf-symbols.ts
+++ b/src/utils/golf-symbols.ts
@@ -33,7 +33,7 @@ export function getScoreSymbol(score: number, par: number): ScoreSymbolInfo {
     return { label: "Birdie", symbol: "○", color: "text-blue-700", bgColor: "bg-blue-100" };
   }
   if (diff === 0) {
-    return { label: "Par", symbol: "-", color: "text-green-700", bgColor: "bg-green-100" };
+    return { label: "Par", symbol: "-", color: "text-green-700", bgColor: "" };
   }
   if (diff === 1) {
     return { label: "Bogey", symbol: "△", color: "text-orange-700", bgColor: "bg-orange-100" };


### PR DESCRIPTION
## Summary
- ラウンド詳細ページのUIを刷新し、横スクロールのホールセレクター＋選択ホール詳細カード表示に変更
- `ScorecardTable` を概要テーブルのみに簡素化（展開ロジック削除）
- ショット詳細の閲覧（`ShotDetailView`）・編集（`HoleEditForm`）UIを追加
- スコア編集用API（`PATCH /api/rounds/[id]/scores`）を追加

## 新規ファイル
- `hole-selector.tsx` — 横スクロールのホール番号ボタン（色分け: バーディー=青, パー=緑, ボギー+=オレンジ）
- `hole-detail-card.tsx` — 選択ホールの詳細カード（ヘッダー・基本スタッツ・ショット詳細）
- `hole-edit-form.tsx` — ホール編集フォーム（スコア/パット/FW/ショット詳細の編集）
- `shot-detail-view.tsx` — ショット詳細表示（ティー/アプローチ/パットをカード形式で表示）
- `api/rounds/[id]/scores/route.ts` — スコアPATCH API

## Test plan
- [ ] ホールセレクターが横スクロールで表示され、色分けが正しいこと
- [ ] ホール選択時に下に詳細カードが表示されること
- [ ] ショット詳細が見やすく表示されること
- [ ] 編集モード切り替えでHoleEditFormが表示されること
- [ ] 保存後にデータが永続化されていること
- [ ] `npm run build` & `npm run lint` エラーなし

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)