### PR TITLE
feat: AIコーチのアドバイスを全集計項目ベースにアップデート (#72)

### DIFF
--- a/src/app/api/advice/route.ts
+++ b/src/app/api/advice/route.ts
@@ -1,45 +1,119 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GoogleGenerativeAI } from "@google/generative-ai";
-import { MemberStats } from "@/types/database";
+import { MemberStats, DetailedMemberStats } from "@/types/database";
 import { HoleAnalysis } from "@/utils/stats";
 
 const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY ?? "");
 
+/** 部内平均（全スタッツ） */
+interface ClubAvgStats {
+  avg_score: number;
+  avg_putts: number;
+  gir_rate: number;
+  fairway_keep_rate: number;
+  avg_birdies: number;
+  scramble_rate: number;
+  par3_avg: number;
+  par4_avg: number;
+  par5_avg: number;
+  bounce_back_rate: number;
+  bogey_avoidance: number;
+  double_bogey_avoidance: number;
+  putts_per_gir: number;
+  three_putt_avoidance: number;
+  one_putt_rate: number;
+  gir_from_fairway: number;
+  gir_from_rough: number;
+}
+
 interface AdviceRequest {
   stats: MemberStats;
   holeAnalysis: HoleAnalysis[];
-  allStatsAvg: {
-    avg_score: number;
-    avg_putts: number;
-    gir_rate: number;
-    fairway_keep_rate: number;
-    scramble_rate: number;
-  };
+  allStatsAvg: ClubAvgStats;
+  detailedStats: DetailedMemberStats | null;
+}
+
+function fmt(v: number, d = 1): string {
+  return v.toFixed(d);
+}
+
+function fmtPct(v: number): string {
+  return `${v.toFixed(1)}%`;
+}
+
+function fmtOpt(v: number | null, unit = ""): string {
+  return v != null ? `${v.toFixed(1)}${unit}` : "データなし";
 }
 
 export async function POST(request: NextRequest) {
   try {
     const body: AdviceRequest = await request.json();
-    const { stats, holeAnalysis, allStatsAvg } = body;
+    const { stats, holeAnalysis, allStatsAvg, detailedStats } = body;
+    const avg = allStatsAvg;
 
-    const prompt = `あなたはプロのゴルフコーチです。以下のプレイヤーのスタッツを分析し、具体的な改善アドバイスを日本語で提供してください。
+    // Build distance stats section
+    let distanceSection = "";
+    if (detailedStats) {
+      const puttDist = detailedStats.make_pct_by_distance;
+      const girDist = detailedStats.gir_by_distance;
 
-## プレイヤーのスタッツ（直近5ラウンド平均）
-- 平均スコア: ${stats.avg_score.toFixed(1)} (部内平均: ${allStatsAvg.avg_score.toFixed(1)})
-- 平均パット: ${stats.avg_putts.toFixed(1)} (部内平均: ${allStatsAvg.avg_putts.toFixed(1)})
-- パーオン率: ${stats.gir_rate.toFixed(1)}% (部内平均: ${allStatsAvg.gir_rate.toFixed(1)}%)
-- FWキープ率: ${stats.fairway_keep_rate.toFixed(1)}% (部内平均: ${allStatsAvg.fairway_keep_rate.toFixed(1)}%)
-- リカバリー率: ${stats.scramble_rate.toFixed(1)}% (部内平均: ${allStatsAvg.scramble_rate.toFixed(1)}%)
+      if (puttDist.length > 0) {
+        distanceSection += "\n## パット距離別カップイン率\n";
+        distanceSection += puttDist
+          .map((d) => `- ${d.label}: ${fmtPct(d.rate)} (${d.count}回)`)
+          .join("\n");
+      }
+
+      if (girDist.length > 0) {
+        distanceSection += "\n\n## 距離別パーオン率\n";
+        distanceSection += girDist
+          .map((d) => `- ${d.label}: ${fmtPct(d.rate)} (${d.count}回)`)
+          .join("\n");
+      }
+    }
+
+    const prompt = `あなたはプロのゴルフコーチです。大学ゴルフ部員のスタッツを分析し、データに基づいた具体的な改善アドバイスを日本語で提供してください。
+
+## コアスタッツ（直近10ラウンド平均）  ※括弧内は部内平均
+- 平均スコア: ${fmt(stats.avg_score)} (${fmt(avg.avg_score)})
+- 平均パット: ${fmt(stats.avg_putts)} (${fmt(avg.avg_putts)})
+- パーオン率: ${fmtPct(stats.gir_rate)} (${fmtPct(avg.gir_rate)})
+- FWキープ率: ${fmtPct(stats.fairway_keep_rate)} (${fmtPct(avg.fairway_keep_rate)})
+- 平均バーディー数: ${fmt(stats.avg_birdies, 2)} (${fmt(avg.avg_birdies, 2)})
+- リカバリー率: ${fmtPct(stats.scramble_rate)} (${fmtPct(avg.scramble_rate)})
+
+## スコアリング
+- Par3平均: ${fmt(stats.par3_avg)} (${fmt(avg.par3_avg)})
+- Par4平均: ${fmt(stats.par4_avg)} (${fmt(avg.par4_avg)})
+- Par5平均: ${fmt(stats.par5_avg)} (${fmt(avg.par5_avg)})
+- バウンスバック率: ${fmtPct(stats.bounce_back_rate)} (${fmtPct(avg.bounce_back_rate)})
+- ボギー回避率: ${fmtPct(stats.bogey_avoidance)} (${fmtPct(avg.bogey_avoidance)})
+- ダボ回避率: ${fmtPct(stats.double_bogey_avoidance)} (${fmtPct(avg.double_bogey_avoidance)})
+
+## パッティング
+- パーオン時パット: ${fmt(stats.putts_per_gir)} (${fmt(avg.putts_per_gir)})
+- 3パット回避率: ${fmtPct(stats.three_putt_avoidance)} (${fmtPct(avg.three_putt_avoidance)})
+- 1パット率: ${fmtPct(stats.one_putt_rate)} (${fmtPct(avg.one_putt_rate)})
+
+## ショット
+- FWからのパーオン率: ${fmtPct(stats.gir_from_fairway)} (${fmtPct(avg.gir_from_fairway)})
+- ラフからのパーオン率: ${fmtPct(stats.gir_from_rough)} (${fmtPct(avg.gir_from_rough)})
+- サンドセーブ率: ${fmtOpt(stats.sand_save_rate, "%")}
+- 平均飛距離: ${fmtOpt(stats.avg_driving_distance, "yd")}
 
 ## ホール別分析
 ${holeAnalysis.map((h) => `- ${h.parType}: 平均${h.avgScore.toFixed(2)}打 (Par比 ${h.avgOverPar >= 0 ? "+" : ""}${h.avgOverPar.toFixed(2)})`).join("\n")}
+${distanceSection}
 
 ## 指示
-1. このプレイヤーの最も改善すべき点を1つ特定してください
-2. その改善のための具体的な練習方法を2つ提案してください
-3. 強みとして伸ばすべき点を1つ挙げてください
+上記の全データを部内平均と比較しながら分析してください。
 
-回答は300文字以内で、励ましの言葉を添えて簡潔にまとめてください。`;
+1. **最優先の改善ポイント**を1つ特定し、なぜそれが最もスコアに影響するか数値を根拠に説明してください
+2. その改善のための**具体的な練習メニュー**を2つ提案してください（ドリル名、回数、意識するポイント）
+3. **強みとして伸ばすべき点**を1つ挙げ、その活かし方を提案してください
+4. 距離別データがある場合は、**苦手な距離帯**への具体的なアプローチも提案してください
+
+回答は400文字以内で、データの裏付けを示しながら簡潔にまとめてください。`;
 
     const model = genAI.getGenerativeModel({
       model: process.env.GEMINI_MODEL ?? "gemini-3.0-flash",

--- a/src/app/my-stats/page.tsx
+++ b/src/app/my-stats/page.tsx
@@ -200,13 +200,28 @@ function MyStatsContent() {
     setAdvice("");
 
     try {
+      const n = allStats.length;
+      const avgOf = (fn: (s: MemberStats) => number) =>
+        allStats.reduce((sum, s) => sum + fn(s), 0) / n;
+
       const allStatsAvg = {
-        avg_score: allStats.reduce((sum, s) => sum + s.avg_score, 0) / allStats.length,
-        avg_putts: allStats.reduce((sum, s) => sum + s.avg_putts, 0) / allStats.length,
-        gir_rate: allStats.reduce((sum, s) => sum + s.gir_rate, 0) / allStats.length,
-        fairway_keep_rate:
-          allStats.reduce((sum, s) => sum + s.fairway_keep_rate, 0) / allStats.length,
-        scramble_rate: allStats.reduce((sum, s) => sum + s.scramble_rate, 0) / allStats.length,
+        avg_score: avgOf((s) => s.avg_score),
+        avg_putts: avgOf((s) => s.avg_putts),
+        gir_rate: avgOf((s) => s.gir_rate),
+        fairway_keep_rate: avgOf((s) => s.fairway_keep_rate),
+        avg_birdies: avgOf((s) => s.avg_birdies),
+        scramble_rate: avgOf((s) => s.scramble_rate),
+        par3_avg: avgOf((s) => s.par3_avg),
+        par4_avg: avgOf((s) => s.par4_avg),
+        par5_avg: avgOf((s) => s.par5_avg),
+        bounce_back_rate: avgOf((s) => s.bounce_back_rate),
+        bogey_avoidance: avgOf((s) => s.bogey_avoidance),
+        double_bogey_avoidance: avgOf((s) => s.double_bogey_avoidance),
+        putts_per_gir: avgOf((s) => s.putts_per_gir),
+        three_putt_avoidance: avgOf((s) => s.three_putt_avoidance),
+        one_putt_rate: avgOf((s) => s.one_putt_rate),
+        gir_from_fairway: avgOf((s) => s.gir_from_fairway),
+        gir_from_rough: avgOf((s) => s.gir_from_rough),
       };
 
       const res = await fetch("/api/advice", {
@@ -216,6 +231,7 @@ function MyStatsContent() {
           stats: myStats,
           holeAnalysis,
           allStatsAvg,
+          detailedStats,
         }),
       });
 


### PR DESCRIPTION
## Summary
- AIアドバイスのプロンプトをコア5指標から**全20+項目**に拡張
- 全項目に**部内平均を併記**し、相対的な強み・弱みを分析可能に
- **距離別データ**（パットカップイン率・パーオン率）も送信
- プロンプト指示を改善: 数値根拠の説明、具体的な練習メニュー、苦手距離帯への提案

## 変更ファイル
- `src/app/api/advice/route.ts` — プロンプト全面刷新、`DetailedMemberStats` 受信対応、距離別セクション動的生成
- `src/app/my-stats/page.tsx` — `allStatsAvg` を全17項目に拡張、`detailedStats` をAPI送信に追加

## プロンプトに含まれる項目
| カテゴリ | 項目 |
|---------|------|
| コア | スコア、パット、GIR、FWキープ、バーディー、リカバリー |
| スコアリング | Par3/4/5平均、バウンスバック、ボギー回避、ダボ回避 |
| パッティング | GIR時パット、3パット回避、1パット率 |
| ショット | FW/ラフからGIR、サンドセーブ、飛距離 |
| 距離別 | パットカップイン率×5帯、パーオン率×6帯 |

## Test plan
- [ ] アドバイス生成ボタンが正常に動作すること
- [ ] 生成されたアドバイスが詳細スタッツに言及していること
- [ ] `detailedStats` がない場合もエラーなく動作すること
- [ ] `npm run build` & `npm run lint` エラーなし

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)