### PR TITLE
feat: バリデーション緩和 - 距離上限999yd・ホール数1〜36H対応

### DIFF
--- a/src/app/api/ocr/ocr.test.ts
+++ b/src/app/api/ocr/ocr.test.ts
@@ -42,8 +42,8 @@ describe("validateDistance", () => {
   it("should return null for invalid distances", () => {
     expect(validateDistance(0)).toBeNull();
     expect(validateDistance(-100)).toBeNull();
-    expect(validateDistance(701)).toBeNull();
     expect(validateDistance(1000)).toBeNull();
+    expect(validateDistance(1500)).toBeNull();
     expect(validateDistance("350")).toBeNull();
     expect(validateDistance(null)).toBeNull();
     expect(validateDistance(undefined)).toBeNull();
@@ -140,7 +140,7 @@ describe("normalizeOcrScores", () => {
 
   it("should validate and reject invalid distance", () => {
     const input = [
-      { hole_number: 1, distance: 800 }, // Too long
+      { hole_number: 1, distance: 1500 }, // Too long (>999)
       { hole_number: 2, distance: 0 }, // Zero
       { hole_number: 3, distance: -100 }, // Negative
     ];

--- a/src/app/api/ocr/route.ts
+++ b/src/app/api/ocr/route.ts
@@ -76,10 +76,10 @@ export function validatePar(par: unknown): 3 | 4 | 5 | null {
 }
 
 /**
- * 距離のバリデーション（1-700ヤード）
+ * 距離のバリデーション（1-999ヤード）
  */
 export function validateDistance(distance: unknown): number | null {
-  if (typeof distance === "number" && distance > 0 && distance <= 700) {
+  if (typeof distance === "number" && distance > 0 && distance <= 999) {
     return Math.round(distance);
   }
   return null;

--- a/src/utils/score-validation.test.ts
+++ b/src/utils/score-validation.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import { validateScores, ScoreInput } from "./score-validation";
+
+/** ヘルパー: 指定ホール数分の正常なスコアデータを生成 */
+function makeValidScores(count: number): ScoreInput[] {
+  return Array.from({ length: count }, (_, i) => ({
+    hole_number: i + 1,
+    par: 4,
+    score: 4,
+    putts: 2,
+    ob: 0,
+    bunker: 0,
+    penalty: 0,
+  }));
+}
+
+// ======================================
+// A. ホール数バリデーション
+// ======================================
+describe("validateScores: ホール数", () => {
+  it("A-1: 9H → エラーなし", () => {
+    expect(validateScores(makeValidScores(9))).toHaveLength(0);
+  });
+
+  it("A-2: 18H → エラーなし", () => {
+    expect(validateScores(makeValidScores(18))).toHaveLength(0);
+  });
+
+  it("A-3: 27H → エラーなし", () => {
+    expect(validateScores(makeValidScores(27))).toHaveLength(0);
+  });
+
+  it("A-4: 36H → エラーなし", () => {
+    expect(validateScores(makeValidScores(36))).toHaveLength(0);
+  });
+
+  it("A-5: 1H（日没等の途中終了）→ エラーなし", () => {
+    expect(validateScores(makeValidScores(1))).toHaveLength(0);
+  });
+
+  it("A-6: 14H（日没で途中終了）→ エラーなし", () => {
+    expect(validateScores(makeValidScores(14))).toHaveLength(0);
+  });
+
+  it("A-7: 0H → エラー", () => {
+    const errors = validateScores([]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("holes");
+  });
+
+  it("A-8: 37H（上限超過）→ エラー", () => {
+    const errors = validateScores(makeValidScores(37));
+    expect(errors.some((e) => e.field === "holes")).toBe(true);
+  });
+});
+
+// ======================================
+// A-ext. 各フィールドの個別バリデーション
+// ======================================
+describe("validateScores: フィールド別", () => {
+  function single(overrides: Partial<ScoreInput>): ScoreInput[] {
+    return [{ hole_number: 1, par: 4, score: 4, putts: 2, ob: 0, bunker: 0, penalty: 0, ...overrides }];
+  }
+
+  // --- par ---
+  it("par=3 → OK", () => {
+    expect(validateScores(single({ par: 3 }))).toHaveLength(0);
+  });
+
+  it("par=6 → OK", () => {
+    expect(validateScores(single({ par: 6 }))).toHaveLength(0);
+  });
+
+  it("par=2 → エラー", () => {
+    const errors = validateScores(single({ par: 2 }));
+    expect(errors.some((e) => e.field === "par")).toBe(true);
+  });
+
+  it("par=7 → エラー", () => {
+    const errors = validateScores(single({ par: 7 }));
+    expect(errors.some((e) => e.field === "par")).toBe(true);
+  });
+
+  // --- score ---
+  it("score=1 → OK", () => {
+    expect(validateScores(single({ score: 1, putts: 0 }))).toHaveLength(0);
+  });
+
+  it("score=20 → OK", () => {
+    expect(validateScores(single({ score: 20 }))).toHaveLength(0);
+  });
+
+  it("score=0 → エラー", () => {
+    const errors = validateScores(single({ score: 0, putts: 0 }));
+    expect(errors.some((e) => e.field === "score")).toBe(true);
+  });
+
+  it("score=21 → エラー", () => {
+    const errors = validateScores(single({ score: 21 }));
+    expect(errors.some((e) => e.field === "score")).toBe(true);
+  });
+
+  // --- putts ---
+  it("putts=0（チップイン）→ OK", () => {
+    expect(validateScores(single({ putts: 0 }))).toHaveLength(0);
+  });
+
+  it("putts=-1 → エラー", () => {
+    const errors = validateScores(single({ putts: -1 }));
+    expect(errors.some((e) => e.field === "putts")).toBe(true);
+  });
+
+  it("putts > score → エラー", () => {
+    const errors = validateScores(single({ score: 4, putts: 5 }));
+    expect(errors.some((e) => e.field === "putts")).toBe(true);
+  });
+
+  it("putts === score → OK", () => {
+    expect(validateScores(single({ score: 4, putts: 4 }))).toHaveLength(0);
+  });
+
+  // --- ob, bunker, penalty ---
+  it("ob=-1 → エラー", () => {
+    expect(validateScores(single({ ob: -1 })).some((e) => e.field === "ob")).toBe(true);
+  });
+
+  it("bunker=-1 → エラー", () => {
+    expect(validateScores(single({ bunker: -1 })).some((e) => e.field === "bunker")).toBe(true);
+  });
+
+  it("penalty=-1 → エラー", () => {
+    expect(validateScores(single({ penalty: -1 })).some((e) => e.field === "penalty")).toBe(true);
+  });
+
+  // --- distance ---
+  it("distance=null → OK（未設定）", () => {
+    expect(validateScores(single({ distance: null }))).toHaveLength(0);
+  });
+
+  it("distance=undefined → OK（未設定）", () => {
+    expect(validateScores(single({ distance: undefined }))).toHaveLength(0);
+  });
+
+  it("distance=1 → OK（下限）", () => {
+    expect(validateScores(single({ distance: 1 }))).toHaveLength(0);
+  });
+
+  it("distance=999 → OK（上限: Par6対応）", () => {
+    expect(validateScores(single({ distance: 999 }))).toHaveLength(0);
+  });
+
+  it("distance=900 → OK（Par6の現実的な距離）", () => {
+    expect(validateScores(single({ distance: 900 }))).toHaveLength(0);
+  });
+
+  it("distance=1000 → エラー（上限超過）", () => {
+    const errors = validateScores(single({ distance: 1000 }));
+    expect(errors.some((e) => e.field === "distance")).toBe(true);
+  });
+
+  it("distance=0 → エラー（下限未満）", () => {
+    const errors = validateScores(single({ distance: 0 }));
+    expect(errors.some((e) => e.field === "distance")).toBe(true);
+  });
+
+  it("distance=-100 → エラー（負の値）", () => {
+    const errors = validateScores(single({ distance: -100 }));
+    expect(errors.some((e) => e.field === "distance")).toBe(true);
+  });
+
+  // --- 複数エラーの複合 ---
+  it("複数フィールドにエラーがあると全て返る", () => {
+    const errors = validateScores(single({ par: 2, score: 0, putts: -1 }));
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/utils/score-validation.ts
+++ b/src/utils/score-validation.ts
@@ -22,8 +22,8 @@ export interface ValidationError {
 export function validateScores(scores: ScoreInput[]): ValidationError[] {
   const errors: ValidationError[] = [];
 
-  // ホール数チェック
-  if (scores.length !== 9 && scores.length !== 18) {
+  // ホール数チェック（1〜36ホール）
+  if (scores.length < 1 || scores.length > 36) {
     errors.push({
       hole_number: 0,
       field: "holes",
@@ -107,11 +107,11 @@ export function validateScores(scores: ScoreInput[]): ValidationError[] {
     }
 
     // 距離の範囲チェック
-    if (s.distance != null && (s.distance < 1 || s.distance > 700)) {
+    if (s.distance != null && (s.distance < 1 || s.distance > 999)) {
       errors.push({
         hole_number: n,
         field: "distance",
-        message: `ホール${n}: 距離は1〜700ydの範囲で入力してください`,
+        message: `ホール${n}: 距離は1〜999ydの範囲で入力してください`,
       });
     }
   }


### PR DESCRIPTION
## Summary
- 距離バリデーションの上限を 700yd → 999yd に拡張（OCR API・スコアバリデーション両方）
- ホール数制限を 9/18 固定 → 1〜36H に緩和（27H 等の変則ラウンドに対応）
- `score-validation.test.ts` を新規追加（32テストケース）

## Test plan
- [x] `npm run build` ビルドエラーなし
- [x] `npx vitest run` 全テストパス（81件）
- [ ] OCR入力で 700yd超のホールが正常に保存できることを確認
- [ ] 27Hラウンドのスコアが保存できることを確認

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)