### PR TITLE
feat: オフラインスコア保存対応

### DIFF
--- a/src/app/input/detailed/page.tsx
+++ b/src/app/input/detailed/page.tsx
@@ -14,6 +14,7 @@ import { authFetch } from "@/lib/api-client";
 import { aggregateHoleData } from "@/utils/shot-aggregation";
 import { validateScores } from "@/utils/score-validation";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { enqueue, isNetworkError, CreateRoundPayload, AddScoresPayload } from "@/lib/offline-queue";
 import { Suspense } from "react";
 
 type InputStep = "settings" | "scoring";
@@ -517,6 +518,69 @@ function DetailedInputContent() {
         router.push("/my-stats");
       }
     } catch (err) {
+      if (!navigator.onLine || isNetworkError(err)) {
+        // Offline: queue for later sync
+        const playedHoles2 = roundData.holes.filter((h) => h.shots.length > 0);
+        const agg = playedHoles2.map((hole) => aggregateHoleData(hole));
+
+        if (addToRoundId) {
+          const scNames = roundData.subCourseIds.map((scId) => {
+            const sc = selectedCourse?.sub_courses.find((s) => s.id === scId);
+            return sc?.name ?? null;
+          }).filter((n): n is string => n !== null);
+
+          enqueue("add-scores", {
+            roundId: addToRoundId,
+            scores: agg.map((a) => ({
+              par: a.par,
+              score: a.score,
+              putts: a.putts,
+              fairway_result: a.fairway_result,
+              ob: a.ob,
+              bunker: a.bunker,
+              penalty: a.penalty,
+              distance: a.distance,
+              pin_position: a.pin_position,
+              shots_detail: a.shots_detail,
+            })),
+            courseLabel: scNames[0] ?? "追加",
+          } satisfies AddScoresPayload);
+        } else {
+          const scNames = roundData.subCourseIds.map((scId) => {
+            const sc = selectedCourse?.sub_courses.find((s) => s.id === scId);
+            return sc?.name ?? null;
+          }).filter((n): n is string => n !== null);
+
+          enqueue("create-round", {
+            memberId: member.id,
+            courseName: roundData.courseName,
+            courseId: roundData.courseId,
+            date: roundData.date,
+            teeColor: roundData.teeColor,
+            outCourseName: scNames[0] ?? null,
+            inCourseName: scNames.length > 1 ? scNames.slice(1).join(" / ") : null,
+            imageUrl: null,
+            scores: agg.map((a) => ({
+              hole_number: a.hole_number,
+              par: a.par,
+              distance: a.distance,
+              score: a.score,
+              putts: a.putts,
+              fairway_result: a.fairway_result,
+              ob: a.ob,
+              bunker: a.bunker,
+              penalty: a.penalty,
+              pin_position: a.pin_position,
+              shots_detail: a.shots_detail,
+            })),
+          } satisfies CreateRoundPayload);
+        }
+
+        clearDraft();
+        router.push(addToRoundId ? `/my-stats/rounds/${addToRoundId}` : "/my-stats");
+        return;
+      }
+
       console.error(err);
       setError(err instanceof Error ? err.message : "保存に失敗しました");
     } finally {

--- a/src/app/input/page.tsx
+++ b/src/app/input/page.tsx
@@ -17,6 +17,8 @@ import { cn } from "@/lib/utils";
 import { getScoreSymbol, getFairwaySymbol } from "@/utils/golf-symbols";
 import { validateScores } from "@/utils/score-validation";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
+import { enqueue, isNetworkError, CreateRoundPayload } from "@/lib/offline-queue";
+import { setCourseCache, getCourseCache } from "@/lib/course-cache";
 
 type Step = "select" | "upload" | "processing" | "confirm";
 
@@ -102,9 +104,15 @@ function InputContent() {
       setStep("confirm");
       setHasDraft(true);
 
-      // コース一覧も取得
+      // コース一覧も取得（オフライン時はキャッシュを利用）
       supabase.from("courses").select("*").order("name").then(({ data }) => {
-        setCourses(data ?? []);
+        if (data) {
+          setCourses(data);
+          setCourseCache(data);
+        } else {
+          const cached = getCourseCache();
+          if (cached) setCourses(cached);
+        }
       });
     }
   }, []);
@@ -171,12 +179,18 @@ function InputContent() {
     setStep("processing");
     setError("");
 
-    // Fetch courses
+    // Fetch courses (with cache fallback)
     const { data: coursesData } = await supabase
       .from("courses")
       .select("*")
       .order("name");
-    setCourses(coursesData ?? []);
+    if (coursesData) {
+      setCourses(coursesData);
+      setCourseCache(coursesData);
+    } else {
+      const cached = getCourseCache();
+      if (cached) setCourses(cached);
+    }
 
     // Call OCR API
     const formData = new FormData();
@@ -352,6 +366,35 @@ function InputContent() {
       isDirty.current = false;
       router.push("/my-stats");
     } catch (err) {
+      if (!navigator.onLine || isNetworkError(err)) {
+        enqueue("create-round", {
+          memberId: member.id,
+          courseName: newCourseName || courses.find((c) => c.id === selectedCourseId)?.name || "",
+          courseId: selectedCourseId || null,
+          date: roundDate,
+          teeColor,
+          outCourseName: outCourseName || null,
+          inCourseName: inCourseName || null,
+          imageUrl: null,
+          scores: scores.map((s) => ({
+            hole_number: s.hole_number,
+            par: s.par,
+            distance: s.distance,
+            score: s.score,
+            putts: s.putts,
+            fairway_result: s.fairway_result,
+            ob: s.ob,
+            bunker: s.bunker,
+            penalty: s.penalty,
+          })),
+        } satisfies CreateRoundPayload);
+
+        clearOcrDraft();
+        isDirty.current = false;
+        router.push("/my-stats");
+        return;
+      }
+
       console.error(err);
       setError("保存に失敗しました");
     } finally {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { BottomNav } from "@/components/layout/bottom-nav";
 import { MobileHeader } from "@/components/layout/mobile-header";
 import { ServiceWorkerRegister } from "@/components/service-worker-register";
+import { OfflineBanner } from "@/components/layout/offline-banner";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -50,6 +51,7 @@ export default function RootLayout({
         <AuthProvider>
           <Sidebar />
           <MobileHeader />
+          <OfflineBanner />
           <main className="md:ml-60 min-h-screen pb-20 md:pb-0">
             <div className="container mx-auto px-4 py-6 max-w-5xl">{children}</div>
           </main>

--- a/src/components/layout/offline-banner.tsx
+++ b/src/components/layout/offline-banner.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { WifiOff, RefreshCw } from "lucide-react";
+import { useOnlineStatus } from "@/hooks/useOnlineStatus";
+
+export function OfflineBanner() {
+  const { isOnline, queueLength } = useOnlineStatus();
+
+  if (isOnline && queueLength === 0) return null;
+
+  if (!isOnline) {
+    return (
+      <div className="bg-amber-100 border-b border-amber-300 px-4 py-2 text-sm text-amber-800 flex items-center gap-2">
+        <WifiOff className="h-4 w-4 shrink-0" />
+        <span>オフラインです。データはローカルに保存されます。</span>
+      </div>
+    );
+  }
+
+  // Online but has pending items
+  return (
+    <div className="bg-blue-100 border-b border-blue-300 px-4 py-2 text-sm text-blue-800 flex items-center gap-2">
+      <RefreshCw className="h-4 w-4 shrink-0 animate-spin" />
+      <span>未送信データを送信中... ({queueLength}件)</span>
+    </div>
+  );
+}

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { processQueue, getQueueLength } from "@/lib/offline-queue";
+
+export function useOnlineStatus() {
+  const [isOnline, setIsOnline] = useState(
+    () => (typeof navigator !== "undefined" ? navigator.onLine : true),
+  );
+  const [queueLength, setQueueLength] = useState(
+    () => (typeof localStorage !== "undefined" ? getQueueLength() : 0),
+  );
+
+  const refreshQueueLength = useCallback(() => {
+    setQueueLength(getQueueLength());
+  }, []);
+
+  useEffect(() => {
+    const handleOnline = async () => {
+      setIsOnline(true);
+      // Auto-sync when back online
+      const pending = getQueueLength();
+      if (pending > 0) {
+        await processQueue();
+        refreshQueueLength();
+      }
+    };
+
+    const handleOffline = () => {
+      setIsOnline(false);
+    };
+
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+
+    // Poll queue length periodically (catches enqueue from other code)
+    const interval = setInterval(refreshQueueLength, 3000);
+
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+      clearInterval(interval);
+    };
+  }, [refreshQueueLength]);
+
+  return { isOnline, queueLength };
+}

--- a/src/lib/course-cache.ts
+++ b/src/lib/course-cache.ts
@@ -1,0 +1,30 @@
+import { Course } from "@/types/database";
+
+const STORAGE_KEY = "golf-course-cache";
+const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+interface CacheEntry {
+  courses: Course[];
+  timestamp: number;
+}
+
+export function setCourseCache(courses: Course[]): void {
+  try {
+    const entry: CacheEntry = { courses, timestamp: Date.now() };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entry));
+  } catch {
+    // storage full or unavailable
+  }
+}
+
+export function getCourseCache(): Course[] | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const entry = JSON.parse(raw) as CacheEntry;
+    if (Date.now() - entry.timestamp > MAX_AGE_MS) return null;
+    return entry.courses;
+  } catch {
+    return null;
+  }
+}

--- a/src/lib/offline-queue.test.ts
+++ b/src/lib/offline-queue.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  enqueue,
+  dequeue,
+  getQueue,
+  getQueueLength,
+  processQueue,
+  isNetworkError,
+  CreateRoundPayload,
+} from "./offline-queue";
+
+// Mock supabase
+vi.mock("@/lib/supabase", () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      insert: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+  },
+}));
+
+// Mock authFetch
+vi.mock("@/lib/api-client", () => ({
+  authFetch: vi.fn(),
+}));
+
+// Simple localStorage mock
+const store: Record<string, string> = {};
+beforeEach(() => {
+  Object.keys(store).forEach((k) => delete store[k]);
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+  });
+  vi.stubGlobal("crypto", {
+    randomUUID: () => "test-uuid-" + Math.random().toString(36).slice(2, 8),
+  });
+});
+
+const samplePayload: CreateRoundPayload = {
+  memberId: "member-1",
+  courseName: "Test Course",
+  courseId: null,
+  date: "2026-01-01",
+  teeColor: "White",
+  outCourseName: null,
+  inCourseName: null,
+  imageUrl: null,
+  scores: [
+    {
+      hole_number: 1,
+      par: 4,
+      distance: 350,
+      score: 5,
+      putts: 2,
+      fairway_result: "keep",
+      ob: 0,
+      bunker: 0,
+      penalty: 0,
+    },
+  ],
+};
+
+// ======================================
+// A. キューCRUD
+// ======================================
+describe("offline-queue: CRUD", () => {
+  it("enqueue adds item and returns id", () => {
+    const id = enqueue("create-round", samplePayload);
+    expect(id).toBeTruthy();
+    expect(getQueue()).toHaveLength(1);
+    expect(getQueue()[0].type).toBe("create-round");
+  });
+
+  it("enqueue multiple items", () => {
+    enqueue("create-round", samplePayload);
+    enqueue("create-round", samplePayload);
+    enqueue("add-scores", { roundId: "r1", scores: [], courseLabel: "OUT" });
+    expect(getQueueLength()).toBe(3);
+  });
+
+  it("dequeue removes specific item", () => {
+    const id1 = enqueue("create-round", samplePayload);
+    const id2 = enqueue("create-round", samplePayload);
+    dequeue(id1);
+    const queue = getQueue();
+    expect(queue).toHaveLength(1);
+    expect(queue[0].id).toBe(id2);
+  });
+
+  it("dequeue non-existent id is no-op", () => {
+    enqueue("create-round", samplePayload);
+    dequeue("non-existent");
+    expect(getQueueLength()).toBe(1);
+  });
+
+  it("getQueue returns empty array for empty queue", () => {
+    expect(getQueue()).toEqual([]);
+  });
+
+  it("getQueueLength returns 0 for empty queue", () => {
+    expect(getQueueLength()).toBe(0);
+  });
+});
+
+// ======================================
+// B. processQueue
+// ======================================
+describe("offline-queue: processQueue", () => {
+  it("returns { synced: 0, failed: 0 } for empty queue", async () => {
+    const result = await processQueue();
+    expect(result).toEqual({ synced: 0, failed: 0 });
+  });
+});
+
+// ======================================
+// C. isNetworkError
+// ======================================
+describe("offline-queue: isNetworkError", () => {
+  it('TypeError("Failed to fetch") → true', () => {
+    expect(isNetworkError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it('TypeError("NetworkError when attempting...") → true', () => {
+    expect(isNetworkError(new TypeError("NetworkError when attempting to fetch"))).toBe(
+      true,
+    );
+  });
+
+  it('TypeError("Network request failed") → true', () => {
+    expect(isNetworkError(new TypeError("Network request failed"))).toBe(true);
+  });
+
+  it("regular Error → false", () => {
+    expect(isNetworkError(new Error("Something went wrong"))).toBe(false);
+  });
+
+  it("object with code NETWORK_ERROR → true", () => {
+    expect(isNetworkError({ code: "NETWORK_ERROR" })).toBe(true);
+  });
+
+  it("null → false", () => {
+    expect(isNetworkError(null)).toBe(false);
+  });
+
+  it("undefined → false", () => {
+    expect(isNetworkError(undefined)).toBe(false);
+  });
+});
+
+// ======================================
+// D. localStorage破損時のフォールバック
+// ======================================
+describe("offline-queue: corrupted localStorage", () => {
+  it("returns empty array when localStorage has invalid JSON", () => {
+    store["golf-offline-queue"] = "not-valid-json{{{";
+    expect(getQueue()).toEqual([]);
+    expect(getQueueLength()).toBe(0);
+  });
+
+  it("enqueue still works after corrupted state", () => {
+    store["golf-offline-queue"] = "corrupted";
+    // enqueue reads the queue first (gets []), then writes
+    const id = enqueue("create-round", samplePayload);
+    expect(id).toBeTruthy();
+    expect(getQueueLength()).toBe(1);
+  });
+});

--- a/src/lib/offline-queue.ts
+++ b/src/lib/offline-queue.ts
@@ -1,0 +1,207 @@
+import { supabase } from "@/lib/supabase";
+import { authFetch } from "@/lib/api-client";
+
+const STORAGE_KEY = "golf-offline-queue";
+
+export type OfflineQueueItemType = "create-round" | "add-scores";
+
+export interface CreateRoundPayload {
+  memberId: string;
+  courseName: string;
+  courseId: string | null;
+  date: string;
+  teeColor: string;
+  outCourseName: string | null;
+  inCourseName: string | null;
+  imageUrl: string | null;
+  scores: {
+    hole_number: number;
+    par: number;
+    distance: number | null;
+    score: number;
+    putts: number;
+    fairway_result: string;
+    ob: number;
+    bunker: number;
+    penalty: number;
+    pin_position?: string | null;
+    shots_detail?: unknown[] | null;
+  }[];
+}
+
+export interface AddScoresPayload {
+  roundId: string;
+  scores: Record<string, unknown>[];
+  courseLabel: string;
+}
+
+export interface OfflineQueueItem {
+  id: string;
+  createdAt: string;
+  type: OfflineQueueItemType;
+  payload: CreateRoundPayload | AddScoresPayload;
+}
+
+function readQueue(): OfflineQueueItem[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as OfflineQueueItem[];
+  } catch {
+    return [];
+  }
+}
+
+function writeQueue(queue: OfflineQueueItem[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(queue));
+  } catch {
+    // storage full or unavailable
+  }
+}
+
+export function enqueue(
+  type: OfflineQueueItemType,
+  payload: CreateRoundPayload | AddScoresPayload,
+): string {
+  const id = crypto.randomUUID();
+  const item: OfflineQueueItem = {
+    id,
+    createdAt: new Date().toISOString(),
+    type,
+    payload,
+  };
+  const queue = readQueue();
+  queue.push(item);
+  writeQueue(queue);
+  return id;
+}
+
+export function getQueue(): OfflineQueueItem[] {
+  return readQueue();
+}
+
+export function dequeue(id: string): void {
+  const queue = readQueue().filter((item) => item.id !== id);
+  writeQueue(queue);
+}
+
+export function getQueueLength(): number {
+  return readQueue().length;
+}
+
+export function isNetworkError(err: unknown): boolean {
+  if (err instanceof TypeError && err.message.includes("Failed to fetch")) {
+    return true;
+  }
+  if (err instanceof TypeError && err.message.includes("NetworkError")) {
+    return true;
+  }
+  if (err instanceof TypeError && err.message.includes("Network request failed")) {
+    return true;
+  }
+  if (
+    err !== null &&
+    typeof err === "object" &&
+    "code" in err &&
+    (err as { code: string }).code === "NETWORK_ERROR"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function processCreateRound(payload: CreateRoundPayload): Promise<void> {
+  // Resolve course ID
+  let courseId = payload.courseId;
+  if (!courseId && payload.courseName) {
+    const { data: existing } = await supabase
+      .from("courses")
+      .select("id")
+      .eq("name", payload.courseName)
+      .single();
+
+    if (existing) {
+      courseId = existing.id;
+    } else {
+      const { data: newCourse, error: courseErr } = await supabase
+        .from("courses")
+        .insert({ name: payload.courseName })
+        .select()
+        .single();
+      if (courseErr) throw courseErr;
+      courseId = newCourse.id;
+    }
+  }
+
+  // Insert round
+  const { data: round, error: roundErr } = await supabase
+    .from("rounds")
+    .insert({
+      member_id: payload.memberId,
+      course_id: courseId,
+      date: payload.date,
+      tee_color: payload.teeColor,
+      image_url: payload.imageUrl,
+      out_course_name: payload.outCourseName,
+      in_course_name: payload.inCourseName,
+    })
+    .select()
+    .single();
+
+  if (roundErr) throw roundErr;
+
+  // Insert scores
+  const scoreRecords = payload.scores.map((s) => ({
+    round_id: round.id,
+    ...s,
+  }));
+
+  const { error: scoresErr } = await supabase.from("scores").insert(scoreRecords);
+  if (scoresErr) throw scoresErr;
+}
+
+async function processAddScores(payload: AddScoresPayload): Promise<void> {
+  const res = await authFetch(`/api/rounds/${payload.roundId}/scores`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      scores: payload.scores,
+      course_label: payload.courseLabel,
+    }),
+  });
+  if (!res.ok) {
+    const err = await res.json();
+    throw new Error(err.error || "Failed to add scores");
+  }
+}
+
+export async function processQueue(): Promise<{ synced: number; failed: number }> {
+  const queue = readQueue();
+  if (queue.length === 0) return { synced: 0, failed: 0 };
+
+  let synced = 0;
+  let failed = 0;
+
+  for (const item of queue) {
+    try {
+      if (item.type === "create-round") {
+        await processCreateRound(item.payload as CreateRoundPayload);
+      } else {
+        await processAddScores(item.payload as AddScoresPayload);
+      }
+      dequeue(item.id);
+      synced++;
+    } catch (err) {
+      if (isNetworkError(err)) {
+        // Still offline, stop processing
+        break;
+      }
+      // Non-network error: skip this item and continue
+      console.error("Failed to process offline queue item:", item.id, err);
+      failed++;
+    }
+  }
+
+  return { synced, failed };
+}


### PR DESCRIPTION
## Summary
- 通信失敗時にlocalStorageキューへ自動保存し、オンライン復帰時に自動同期
- コース一覧の24時間キャッシュでオフライン時もコース選択可能
- オフラインバナーUI（状態通知 + 同期中表示）
- 詳細ショット入力・OCR入力の両方に対応

## 新規ファイル
- `src/lib/offline-queue.ts` - 保存キュー（enqueue/dequeue/processQueue/isNetworkError）
- `src/lib/offline-queue.test.ts` - キューのユニットテスト（16件）
- `src/lib/course-cache.ts` - コース一覧のlocalStorageキャッシュ
- `src/hooks/useOnlineStatus.ts` - online/offline検知 + キュー件数
- `src/components/layout/offline-banner.tsx` - オフラインバナーUI

## 変更ファイル
- `src/app/layout.tsx` - OfflineBannerの追加
- `src/app/input/detailed/page.tsx` - executeSaveのcatchでオフラインキュー追加
- `src/app/input/page.tsx` - handleSaveのcatchでオフラインキュー追加 + コースキャッシュ統合

## Test plan
- [x] `npm test` - 225テスト全パス
- [x] `npm run build` - ビルド成功
- [x] `npm run lint` - 新規lintエラーなし
- [ ] オフライン状態でスコア保存 → キューに保存されることを確認
- [ ] オンライン復帰時に自動同期されることを確認

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)