### PR TITLE
fix: オフラインバナーのハイドレーション不整合を修正

### DIFF
--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,47 +1,68 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useSyncExternalStore, useEffect } from "react";
 import { processQueue, getQueueLength } from "@/lib/offline-queue";
 
+// --- Online status (navigator.onLine) ---
+
+function subscribeOnline(callback: () => void) {
+  window.addEventListener("online", callback);
+  window.addEventListener("offline", callback);
+  return () => {
+    window.removeEventListener("online", callback);
+    window.removeEventListener("offline", callback);
+  };
+}
+
+function getOnlineSnapshot() {
+  return navigator.onLine;
+}
+
+function getServerOnlineSnapshot() {
+  return true;
+}
+
+// --- Queue length (localStorage polling) ---
+
+function subscribeQueue(callback: () => void) {
+  const interval = setInterval(callback, 3000);
+  // Also refresh on online event (after sync completes)
+  window.addEventListener("online", callback);
+  return () => {
+    clearInterval(interval);
+    window.removeEventListener("online", callback);
+  };
+}
+
+function getQueueSnapshot() {
+  return getQueueLength();
+}
+
+function getServerQueueSnapshot() {
+  return 0;
+}
+
+// --- Hook ---
+
 export function useOnlineStatus() {
-  const [isOnline, setIsOnline] = useState(
-    () => (typeof navigator !== "undefined" ? navigator.onLine : true),
-  );
-  const [queueLength, setQueueLength] = useState(
-    () => (typeof localStorage !== "undefined" ? getQueueLength() : 0),
+  const isOnline = useSyncExternalStore(
+    subscribeOnline,
+    getOnlineSnapshot,
+    getServerOnlineSnapshot,
   );
 
-  const refreshQueueLength = useCallback(() => {
-    setQueueLength(getQueueLength());
-  }, []);
+  const queueLength = useSyncExternalStore(
+    subscribeQueue,
+    getQueueSnapshot,
+    getServerQueueSnapshot,
+  );
 
+  // Auto-sync when back online
   useEffect(() => {
-    const handleOnline = async () => {
-      setIsOnline(true);
-      // Auto-sync when back online
-      const pending = getQueueLength();
-      if (pending > 0) {
-        await processQueue();
-        refreshQueueLength();
-      }
-    };
-
-    const handleOffline = () => {
-      setIsOnline(false);
-    };
-
-    window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
-
-    // Poll queue length periodically (catches enqueue from other code)
-    const interval = setInterval(refreshQueueLength, 3000);
-
-    return () => {
-      window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
-      clearInterval(interval);
-    };
-  }, [refreshQueueLength]);
+    if (isOnline && getQueueLength() > 0) {
+      processQueue();
+    }
+  }, [isOnline]);
 
   return { isOnline, queueLength };
 }


### PR DESCRIPTION
## Summary
- `useOnlineStatus` hookの `useState` lazy initializer → `useSyncExternalStore` に移行
- SSR/クライアント間のハイドレーション不整合を解消
- オンライン時にオフラインバナーが表示される問題を修正
- ハイドレーションエラーによるラウンド履歴非表示を修正

## 原因
`useState(() => navigator.onLine)` がSSR時（`true`）とクライアント時（環境次第で`false`）で異なる値を返し、ReactのSSRハイドレーションでHTMLの不一致が発生。これによりページ全体のレンダリングが壊れていた。

## 修正内容
`useSyncExternalStore` を使用:
- `getServerSnapshot`: SSR時は常に `true`/`0` を返す
- `getSnapshot`: クライアント側で `navigator.onLine`/`getQueueLength()` を返す
- Reactが差異を検知した場合、クライアント側で正しく再レンダリングを行う

## Test plan
- [x] `npm test` - 225テスト全パス
- [x] `npm run build` - ビルド成功
- [x] `npm run lint` - 新規lintエラーなし（useOnlineStatusのset-state-in-effectも解消）
- [ ] オンライン時にオフラインバナーが表示されないことを確認
- [ ] ラウンド履歴が正常に表示されることを確認

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)