### PR TITLE
fix: オフライン機能の修正（バナー/CourseSelector/SW）

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,24 +1,42 @@
-const CACHE_NAME = "golf-dashboard-v1";
-const OFFLINE_URL = "/offline";
+const CACHE_NAME = "golf-dashboard-v2";
 
 self.addEventListener("install", (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.add(OFFLINE_URL))
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.addAll(["/offline"])
+    )
   );
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(
-        keys
-          .filter((key) => key !== CACHE_NAME)
-          .map((key) => caches.delete(key))
-      )
-    )
+    Promise.all([
+      // Clean old caches
+      caches.keys().then((keys) =>
+        Promise.all(
+          keys
+            .filter((key) => key !== CACHE_NAME)
+            .map((key) => caches.delete(key))
+        )
+      ),
+      // Cache pages of existing clients (handles first-visit race condition)
+      self.clients.matchAll({ type: "window" }).then((windowClients) =>
+        caches.open(CACHE_NAME).then((cache) =>
+          Promise.all(
+            windowClients.map((client) => {
+              const url = new URL(client.url);
+              return fetch(url.pathname)
+                .then((res) => {
+                  if (res.ok) return cache.put(url.pathname, res);
+                })
+                .catch(() => {});
+            })
+          )
+        )
+      ),
+    ]).then(() => self.clients.claim())
   );
-  self.clients.claim();
 });
 
 self.addEventListener("fetch", (event) => {
@@ -29,19 +47,32 @@ self.addEventListener("fetch", (event) => {
   // Skip cross-origin requests
   if (url.origin !== self.location.origin) return;
 
-  // Navigation requests: network-first, fallback to offline page
-  if (event.request.mode === "navigate") {
+  // Skip API routes - let offline-queue handle failures
+  if (url.pathname.startsWith("/api/")) return;
+
+  // Static assets (JS/CSS bundles, icons, fonts): cache-first
+  if (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname.startsWith("/icons/") ||
+    url.pathname.endsWith(".png") ||
+    url.pathname.endsWith(".ico") ||
+    url.pathname.endsWith(".webmanifest")
+  ) {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+      caches.match(event.request).then((cached) => {
+        if (cached) return cached;
+        return fetch(event.request).then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+          return response;
+        });
+      })
     );
     return;
   }
 
-  // Static assets: network-first with cache
-  if (
-    url.pathname.startsWith("/_next/static/") ||
-    url.pathname.startsWith("/icons/")
-  ) {
+  // Navigation requests & Next.js data: network-first, cache fallback
+  if (event.request.mode === "navigate" || url.pathname.startsWith("/_next/data/")) {
     event.respondWith(
       fetch(event.request)
         .then((response) => {
@@ -49,7 +80,23 @@ self.addEventListener("fetch", (event) => {
           caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
           return response;
         })
-        .catch(() => caches.match(event.request))
+        .catch(() =>
+          caches.match(event.request).then((cached) =>
+            cached || caches.match("/offline")
+          )
+        )
     );
+    return;
   }
+
+  // Other same-origin GET: network-first with cache
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        const clone = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, clone));
+        return response;
+      })
+      .catch(() => caches.match(event.request))
+  );
 });

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,13 +1,27 @@
+"use client";
+
+import { WifiOff } from "lucide-react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
 export default function OfflinePage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-[60vh] text-center px-4">
-      <span className="text-6xl mb-6" role="img" aria-label="golf">
-        &#9971;
-      </span>
+      <WifiOff className="h-16 w-16 text-amber-500 mb-6" />
       <h1 className="text-2xl font-bold mb-2">オフラインです</h1>
-      <p className="text-muted-foreground">
-        インターネット接続を確認して、もう一度お試しください。
+      <p className="text-muted-foreground mb-6">
+        このページはまだキャッシュされていません。
+        <br />
+        一度オンラインでアクセスしたページはオフラインでも利用できます。
       </p>
+      <div className="flex gap-3">
+        <Button variant="outline" onClick={() => window.location.reload()}>
+          再読み込み
+        </Button>
+        <Link href="/input/detailed">
+          <Button>スコア入力へ</Button>
+        </Link>
+      </div>
     </div>
   );
 }

--- a/src/components/course/course-selector.tsx
+++ b/src/components/course/course-selector.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 import { Search, X, Loader2 } from "lucide-react";
+import { setCourseCache, getCourseCache, setCourseDetailCache, getCourseDetailCache } from "@/lib/course-cache";
 
 interface CourseSelectorProps {
   onCourseSelect: (course: CourseWithDetails | null) => void;
@@ -27,7 +28,7 @@ export function CourseSelector({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // 軽量な一覧取得（名前・都道府県のみ）
+  // 軽量な一覧取得（名前・都道府県のみ）- オフライン時はキャッシュにフォールバック
   useEffect(() => {
     const fetchCourses = async () => {
       try {
@@ -35,12 +36,19 @@ export function CourseSelector({
         if (res.ok) {
           const data = await res.json();
           setCourses(data);
+          setCourseCache(data);
+          setIsLoading(false);
+          return;
         }
       } catch {
-        console.error("コース一覧の取得に失敗しました");
-      } finally {
-        setIsLoading(false);
+        // network error - fall through to cache
       }
+      // Fallback to cache
+      const cached = getCourseCache();
+      if (cached) {
+        setCourses(cached);
+      }
+      setIsLoading(false);
     };
     fetchCourses();
   }, []);
@@ -80,7 +88,7 @@ export function CourseSelector({
 
   const selectedCourse = courses.find((c) => c.id === selectedCourseId);
 
-  // 選択時に詳細をフェッチ
+  // 選択時に詳細をフェッチ - オフライン時はキャッシュにフォールバック
   const handleCourseChange = async (courseId: string) => {
     setSelectedCourseId(courseId);
     setIsDropdownOpen(false);
@@ -95,13 +103,27 @@ export function CourseSelector({
       const res = await fetch(`/api/courses/${courseId}`);
       if (res.ok) {
         const detail: CourseWithDetails = await res.json();
+        setCourseDetailCache(detail);
         onCourseSelect(detail);
+        setIsFetchingDetail(false);
+        return;
       }
     } catch {
-      console.error("コース詳細の取得に失敗しました");
-    } finally {
-      setIsFetchingDetail(false);
+      // network error - fall through to cache
     }
+    // Fallback to cache
+    const cached = getCourseDetailCache(courseId);
+    if (cached) {
+      onCourseSelect(cached);
+    } else {
+      // No cache: switch to manual mode with course name preserved
+      const course = courses.find((c) => c.id === courseId);
+      if (course) {
+        onManualInput(course.name);
+        setMode("manual");
+      }
+    }
+    setIsFetchingDetail(false);
   };
 
   const handleClear = () => {

--- a/src/components/service-worker-register.tsx
+++ b/src/components/service-worker-register.tsx
@@ -2,11 +2,80 @@
 
 import { useEffect } from "react";
 
+const CACHE_NAME = "golf-dashboard-v2";
+
+/** SW有効化後に現在のページと読み込み済みリソースをキャッシュに保存 */
+async function warmCache() {
+  // ページ読み込み完了を待つ
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+
+  const cache = await caches.open(CACHE_NAME);
+
+  // 1. 現在のページHTMLをキャッシュ
+  try {
+    const res = await fetch(window.location.pathname);
+    if (res.ok) {
+      await cache.put(window.location.pathname, res);
+    }
+  } catch {
+    /* ignore */
+  }
+
+  // 2. 読み込み済みの同一オリジンリソース（JSチャンク等）をキャッシュ
+  const resources = performance.getEntriesByType("resource") as PerformanceResourceTiming[];
+  for (const entry of resources) {
+    try {
+      const url = new URL(entry.name);
+      if (url.origin !== window.location.origin) continue;
+      if (url.pathname.startsWith("/api/")) continue;
+
+      const existing = await cache.match(url.pathname);
+      if (existing) continue;
+
+      const res = await fetch(entry.name);
+      if (res.ok) {
+        await cache.put(entry.name, res);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // 3. スコア入力ページをバックグラウンドでプリキャッシュ
+  const pages = ["/input", "/input/detailed"];
+  for (const page of pages) {
+    try {
+      const existing = await cache.match(page);
+      if (existing) continue;
+      const res = await fetch(page);
+      if (res.ok) {
+        await cache.put(page, res);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
 export function ServiceWorkerRegister() {
   useEffect(() => {
-    if ("serviceWorker" in navigator) {
-      navigator.serviceWorker.register("/sw.js");
-    }
+    if (!("serviceWorker" in navigator)) return;
+
+    navigator.serviceWorker.register("/sw.js").then((reg) => {
+      const sw = reg.active || reg.installing || reg.waiting;
+      if (!sw) return;
+
+      if (sw.state === "activated") {
+        warmCache();
+      } else {
+        sw.addEventListener("statechange", function handler() {
+          if (sw.state === "activated") {
+            sw.removeEventListener("statechange", handler);
+            warmCache();
+          }
+        });
+      }
+    });
   }, []);
 
   return null;

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -3,19 +3,31 @@
 import { useSyncExternalStore, useEffect } from "react";
 import { processQueue, getQueueLength } from "@/lib/offline-queue";
 
-// --- Online status (navigator.onLine) ---
+// --- Online status ---
+// navigator.onLine is unreliable (returns false in some environments even when online).
+// Start optimistically as "online" and only react to browser offline/online events.
+
+let onlineState = true;
 
 function subscribeOnline(callback: () => void) {
-  window.addEventListener("online", callback);
-  window.addEventListener("offline", callback);
+  const handleOnline = () => {
+    onlineState = true;
+    callback();
+  };
+  const handleOffline = () => {
+    onlineState = false;
+    callback();
+  };
+  window.addEventListener("online", handleOnline);
+  window.addEventListener("offline", handleOffline);
   return () => {
-    window.removeEventListener("online", callback);
-    window.removeEventListener("offline", callback);
+    window.removeEventListener("online", handleOnline);
+    window.removeEventListener("offline", handleOffline);
   };
 }
 
 function getOnlineSnapshot() {
-  return navigator.onLine;
+  return onlineState;
 }
 
 function getServerOnlineSnapshot() {
@@ -26,7 +38,6 @@ function getServerOnlineSnapshot() {
 
 function subscribeQueue(callback: () => void) {
   const interval = setInterval(callback, 3000);
-  // Also refresh on online event (after sync completes)
   window.addEventListener("online", callback);
   return () => {
     clearInterval(interval);

--- a/src/lib/course-cache.ts
+++ b/src/lib/course-cache.ts
@@ -1,12 +1,19 @@
-import { Course } from "@/types/database";
+import { Course, CourseWithDetails } from "@/types/database";
 
 const STORAGE_KEY = "golf-course-cache";
+const DETAIL_STORAGE_KEY = "golf-course-detail-cache";
 const MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 interface CacheEntry {
   courses: Course[];
   timestamp: number;
 }
+
+interface DetailCacheStore {
+  [courseId: string]: { data: CourseWithDetails; timestamp: number };
+}
+
+// --- Course list cache ---
 
 export function setCourseCache(courses: Course[]): void {
   try {
@@ -24,6 +31,40 @@ export function getCourseCache(): Course[] | null {
     const entry = JSON.parse(raw) as CacheEntry;
     if (Date.now() - entry.timestamp > MAX_AGE_MS) return null;
     return entry.courses;
+  } catch {
+    return null;
+  }
+}
+
+// --- Course detail cache ---
+
+function readDetailStore(): DetailCacheStore {
+  try {
+    const raw = localStorage.getItem(DETAIL_STORAGE_KEY);
+    if (!raw) return {};
+    return JSON.parse(raw) as DetailCacheStore;
+  } catch {
+    return {};
+  }
+}
+
+export function setCourseDetailCache(course: CourseWithDetails): void {
+  try {
+    const store = readDetailStore();
+    store[course.id] = { data: course, timestamp: Date.now() };
+    localStorage.setItem(DETAIL_STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // storage full or unavailable
+  }
+}
+
+export function getCourseDetailCache(courseId: string): CourseWithDetails | null {
+  try {
+    const store = readDetailStore();
+    const entry = store[courseId];
+    if (!entry) return null;
+    if (Date.now() - entry.timestamp > MAX_AGE_MS) return null;
+    return entry.data;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
PR #83 でマージしたオフライン機能に対する修正をまとめたPR。

### 修正内容
- **オフラインバナーが常時表示される問題**: `navigator.onLine` が環境によって不正確に `false` を返す問題 → `useSyncExternalStore` + イベント駆動に変更し、初期値は楽観的に `true`
- **オフライン時にスコア入力ページが使えない問題**: `CourseSelector` がオフライン時にキャッシュフォールバックしていなかった → コース一覧・詳細のキャッシュ対応、キャッシュなし時は手動入力モードに自動切替
- **オフラインリロードで全画面エラーになる問題**: SWが初回訪問時のHTML/JSチャンクをキャッシュしていなかった → SW activate時 + クライアント側でのwarmCache実装

### 変更ファイル (6件)
| ファイル | 変更内容 |
|---|---|
| `public/sw.js` | activate時に既存クライアントURLをプリキャッシュ |
| `src/components/service-worker-register.tsx` | SW有効化後にページ・JSチャンク・入力ページをキャッシュ |
| `src/hooks/useOnlineStatus.ts` | `useSyncExternalStore` + イベント駆動のオンライン検知 |
| `src/components/course/course-selector.tsx` | コース一覧・詳細fetchのキャッシュフォールバック |
| `src/lib/course-cache.ts` | コース詳細キャッシュ機能を追加 |
| `src/app/offline/page.tsx` | スコア入力への導線付きに改善 |

## Test plan
- [x] `npm test` - 225テスト全パス
- [x] `npm run build` - ビルド成功
- [x] `npm run lint` - 新規lintエラーなし
- [ ] オンライン時にオフラインバナーが表示されないことを確認
- [ ] オフライン時にスコア入力ページが動作することを確認
- [ ] オフラインリロードでアプリが表示されることを確認

Closes #84 Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)