### PR TITLE
fix: データ取得エラーをユーザーに表示する

### DIFF
--- a/src/app/my-stats/page.tsx
+++ b/src/app/my-stats/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { RequireAuth } from "@/components/auth/require-auth";
@@ -23,6 +23,7 @@ import { PuttHeatmap } from "@/components/putt-heatmap";
 import { ClubSetEditor } from "@/components/club-set-editor";
 import { CourseAnalysisTab } from "@/components/course-analysis-tab";
 import { RoundHistoryTab } from "@/components/round-history/round-list";
+import { FetchError } from "@/components/fetch-error";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   Loader2, Sparkles, Settings, Check, ChevronDown, ChevronUp,
@@ -86,6 +87,7 @@ function MyStatsContent() {
   const [advice, setAdvice] = useState<string>("");
   const [isLoadingAdvice, setIsLoadingAdvice] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
   // Profile editing state
   const [isProfileSectionOpen, setIsProfileSectionOpen] = useState(false);
@@ -141,29 +143,32 @@ function MyStatsContent() {
     }
   };
 
-  useEffect(() => {
+  const fetchData = useCallback(async () => {
     if (!member) return;
 
-    async function fetchData() {
-      // Fetch all rounds with scores and member info (including distance and shots_detail)
-      const { data: rounds, error } = await supabase
-        .from("rounds")
-        .select(
-          `
-          id,
-          member_id,
-          date,
-          members!inner(name),
-          scores(hole_number, par, score, putts, fairway_result, distance, shots_detail)
-        `
-        )
-        .order("date", { ascending: false });
+    setIsLoading(true);
+    setFetchError(null);
 
-      if (error) {
-        console.error("Failed to fetch rounds:", error);
-        setIsLoading(false);
-        return;
-      }
+    // Fetch all rounds with scores and member info (including distance and shots_detail)
+    const { data: rounds, error } = await supabase
+      .from("rounds")
+      .select(
+        `
+        id,
+        member_id,
+        date,
+        members!inner(name),
+        scores(hole_number, par, score, putts, fairway_result, distance, shots_detail)
+      `
+      )
+      .order("date", { ascending: false });
+
+    if (error) {
+      console.error("Failed to fetch rounds:", error);
+      setFetchError("スタッツデータの取得に失敗しました。通信状況を確認してください。");
+      setIsLoading(false);
+      return;
+    }
 
       // Transform data for calculation
       const roundData = (rounds ?? []).map((r) => ({
@@ -234,10 +239,11 @@ function MyStatsContent() {
       setDetailedStats(detailed);
 
       setIsLoading(false);
-    }
-
-    fetchData();
   }, [member]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const generateAdvice = async () => {
     if (!myStats || allStats.length === 0) return;
@@ -314,6 +320,15 @@ function MyStatsContent() {
     const c = clubComparisons[cat];
     return c ? { clubAvg: c.clubAvg, rank: c.rank, totalMembers: c.totalMembers } : {};
   };
+
+  if (fetchError) {
+    return (
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold">マイページ</h2>
+        <FetchError message={fetchError} onRetry={fetchData} />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Badge } from "@/components/ui/badge";
@@ -14,59 +14,65 @@ import {
   RankingCategory,
 } from "@/utils/ranking";
 import { getRankableStatsByGroup } from "@/utils/stat-definitions";
+import { FetchError } from "@/components/fetch-error";
 
 const rankableGroups = getRankableStatsByGroup();
 
 export default function DashboardPage() {
   const [stats, setStats] = useState<MemberStats[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [selectedGroup, setSelectedGroup] = useState(rankableGroups[0]?.group.key ?? "core");
 
-  useEffect(() => {
-    async function fetchData() {
-      // Fetch all rounds with scores and member info, ordered by date desc
-      const { data: rounds, error } = await supabase
-        .from("rounds")
-        .select(
-          `
-          id,
-          member_id,
-          date,
-          members!inner(name),
-          scores(hole_number, par, score, putts, fairway_result, distance, shots_detail)
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setFetchError(null);
+
+    // Fetch all rounds with scores and member info, ordered by date desc
+    const { data: rounds, error } = await supabase
+      .from("rounds")
+      .select(
         `
-        )
-        .order("date", { ascending: false });
+        id,
+        member_id,
+        date,
+        members!inner(name),
+        scores(hole_number, par, score, putts, fairway_result, distance, shots_detail)
+      `
+      )
+      .order("date", { ascending: false });
 
-      if (error) {
-        console.error("Failed to fetch rounds:", error);
-        setIsLoading(false);
-        return;
-      }
-
-      // Transform data for calculation
-      const roundData = (rounds ?? []).map((r) => ({
-        member_id: r.member_id,
-        member_name: (r.members as unknown as { name: string }).name,
-        scores: r.scores as {
-          hole_number: number;
-          par: number;
-          score: number;
-          putts: number;
-          fairway_result: string;
-          distance: number | null;
-          shots_detail: unknown[] | null;
-        }[],
-      }));
-
-      const calculatedStats = calculateMemberStats(roundData);
-      setStats(calculatedStats);
-
+    if (error) {
+      console.error("Failed to fetch rounds:", error);
+      setFetchError("ランキングデータの取得に失敗しました。通信状況を確認してください。");
       setIsLoading(false);
+      return;
     }
 
-    fetchData();
+    // Transform data for calculation
+    const roundData = (rounds ?? []).map((r) => ({
+      member_id: r.member_id,
+      member_name: (r.members as unknown as { name: string }).name,
+      scores: r.scores as {
+        hole_number: number;
+        par: number;
+        score: number;
+        putts: number;
+        fairway_result: string;
+        distance: number | null;
+        shots_detail: unknown[] | null;
+      }[],
+    }));
+
+    const calculatedStats = calculateMemberStats(roundData);
+    setStats(calculatedStats);
+
+    setIsLoading(false);
   }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
 
   const getRankBadgeColor = (rank: number) => {
     if (rank === 1) return "bg-yellow-500 text-white";
@@ -78,6 +84,15 @@ export default function DashboardPage() {
   // Get stats for currently selected group
   const currentGroupData = rankableGroups.find((g) => g.group.key === selectedGroup);
   const currentStats = currentGroupData?.stats ?? [];
+
+  if (fetchError) {
+    return (
+      <div className="space-y-6">
+        <h2 className="text-2xl font-bold">総合ランキング</h2>
+        <FetchError message={fetchError} onRetry={fetchData} />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">

--- a/src/components/course-analysis-tab.tsx
+++ b/src/components/course-analysis-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useMemo, type ReactNode } from "react";
+import { useEffect, useState, useMemo, useCallback, type ReactNode } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
@@ -49,6 +49,7 @@ import {
   Flag, TrendingUp, Triangle, Square, Star,
   Locate, Trees,
 } from "lucide-react";
+import { FetchError } from "@/components/fetch-error";
 
 /** パターアイコン */
 function PutterIcon({ className }: { className?: string }) {
@@ -128,89 +129,95 @@ export function CourseAnalysisTab({ memberId }: CourseAnalysisTabProps) {
   const [selectedHole, setSelectedHole] = useState<number | null>(null);
   const [isLoadingCourses, setIsLoadingCourses] = useState(true);
   const [isLoadingData, setIsLoadingData] = useState(false);
+  const [fetchCoursesError, setFetchCoursesError] = useState<string | null>(null);
+  const [fetchDataError, setFetchDataError] = useState<string | null>(null);
 
   // Fetch played courses
-  useEffect(() => {
-    async function fetchCourses() {
-      const { data, error } = await supabase
-        .from("rounds")
-        .select("course_id, courses!inner(id, name, pref)")
-        .eq("member_id", memberId)
-        .not("course_id", "is", null);
+  const fetchCourses = useCallback(async () => {
+    setIsLoadingCourses(true);
+    setFetchCoursesError(null);
 
-      if (error) {
-        console.error("Failed to fetch courses:", error);
-        setIsLoadingCourses(false);
-        return;
-      }
+    const { data, error } = await supabase
+      .from("rounds")
+      .select("course_id, courses!inner(id, name, pref)")
+      .eq("member_id", memberId)
+      .not("course_id", "is", null);
 
-      const courseMap = new Map<string, CourseOption>();
-      for (const row of data ?? []) {
-        const course = row.courses as unknown as { id: string; name: string; pref: string | null };
-        if (!courseMap.has(course.id)) {
-          courseMap.set(course.id, { id: course.id, name: course.name, pref: course.pref });
-        }
-      }
-
-      setCourses(Array.from(courseMap.values()).sort((a, b) => a.name.localeCompare(b.name)));
+    if (error) {
+      console.error("Failed to fetch courses:", error);
+      setFetchCoursesError("コース一覧の取得に失敗しました。通信状況を確認してください。");
       setIsLoadingCourses(false);
+      return;
     }
 
-    fetchCourses();
+    const courseMap = new Map<string, CourseOption>();
+    for (const row of data ?? []) {
+      const course = row.courses as unknown as { id: string; name: string; pref: string | null };
+      if (!courseMap.has(course.id)) {
+        courseMap.set(course.id, { id: course.id, name: course.name, pref: course.pref });
+      }
+    }
+
+    setCourses(Array.from(courseMap.values()).sort((a, b) => a.name.localeCompare(b.name)));
+    setIsLoadingCourses(false);
   }, [memberId]);
 
-  // Fetch data when course is selected
   useEffect(() => {
+    fetchCourses();
+  }, [fetchCourses]);
+
+  // Fetch data when course is selected
+  const fetchCourseData = useCallback(async () => {
     if (!selectedCourseId) return;
 
-    async function fetchCourseData() {
-      setIsLoadingData(true);
-      setSelectedHole(null);
+    setIsLoadingData(true);
+    setFetchDataError(null);
+    setSelectedHole(null);
 
-      const [myResult, teamResult] = await Promise.all([
-        supabase
-          .from("rounds")
-          .select("id, date, out_course_name, in_course_name, scores(hole_number, par, score, putts, fairway_result, pin_position, shots_detail)")
-          .eq("member_id", memberId)
-          .eq("course_id", selectedCourseId)
-          .order("date", { ascending: false }),
-        supabase
-          .from("rounds")
-          .select("id, member_id, scores(hole_number, par, score, putts, fairway_result)")
-          .eq("course_id", selectedCourseId)
-          .order("date", { ascending: false }),
-      ]);
+    const [myResult, teamResult] = await Promise.all([
+      supabase
+        .from("rounds")
+        .select("id, date, out_course_name, in_course_name, scores(hole_number, par, score, putts, fairway_result, pin_position, shots_detail)")
+        .eq("member_id", memberId)
+        .eq("course_id", selectedCourseId)
+        .order("date", { ascending: false }),
+      supabase
+        .from("rounds")
+        .select("id, member_id, scores(hole_number, par, score, putts, fairway_result)")
+        .eq("course_id", selectedCourseId)
+        .order("date", { ascending: false }),
+    ]);
 
-      if (myResult.error) {
-        console.error("Failed to fetch my rounds:", myResult.error);
-      } else {
-        setMyRounds(
-          (myResult.data ?? []).map((r) => ({
-            id: r.id,
-            date: r.date,
-            out_course_name: (r as Record<string, unknown>).out_course_name as string | null,
-            in_course_name: (r as Record<string, unknown>).in_course_name as string | null,
-            scores: (r.scores as ScoreRow[]) ?? [],
-          }))
-        );
-      }
-
-      if (teamResult.error) {
-        console.error("Failed to fetch team rounds:", teamResult.error);
-      } else {
-        setTeamRounds(
-          (teamResult.data ?? []).map((r) => ({
-            member_id: r.member_id,
-            scores: (r.scores as unknown as ScoreRow[]) ?? [],
-          }))
-        );
-      }
-
+    if (myResult.error || teamResult.error) {
+      console.error("Failed to fetch course data:", myResult.error || teamResult.error);
+      setFetchDataError("コースデータの取得に失敗しました。通信状況を確認してください。");
       setIsLoadingData(false);
+      return;
     }
 
-    fetchCourseData();
+    setMyRounds(
+      (myResult.data ?? []).map((r) => ({
+        id: r.id,
+        date: r.date,
+        out_course_name: (r as Record<string, unknown>).out_course_name as string | null,
+        in_course_name: (r as Record<string, unknown>).in_course_name as string | null,
+        scores: (r.scores as ScoreRow[]) ?? [],
+      }))
+    );
+
+    setTeamRounds(
+      (teamResult.data ?? []).map((r) => ({
+        member_id: r.member_id,
+        scores: (r.scores as unknown as ScoreRow[]) ?? [],
+      }))
+    );
+
+    setIsLoadingData(false);
   }, [memberId, selectedCourseId]);
+
+  useEffect(() => {
+    fetchCourseData();
+  }, [fetchCourseData]);
 
   // All my scores for this course (flat array)
   const allMyScores = useMemo(() => myRounds.flatMap((r) => r.scores), [myRounds]);
@@ -384,6 +391,10 @@ export function CourseAnalysisTab({ memberId }: CourseAnalysisTabProps) {
     return allMyScores.some((s) => s.hole_number === selectedHole && s.pin_position);
   }, [allMyScores, selectedHole]);
 
+  if (fetchCoursesError) {
+    return <FetchError message={fetchCoursesError} onRetry={fetchCourses} />;
+  }
+
   if (isLoadingCourses) {
     return (
       <div className="flex items-center justify-center py-12">
@@ -425,6 +436,10 @@ export function CourseAnalysisTab({ memberId }: CourseAnalysisTabProps) {
             コースを選択してください
           </CardContent>
         </Card>
+      )}
+
+      {fetchDataError && (
+        <FetchError message={fetchDataError} onRetry={fetchCourseData} />
       )}
 
       {isLoadingData && (

--- a/src/components/fetch-error.test.tsx
+++ b/src/components/fetch-error.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FetchError } from "./fetch-error";
+
+describe("FetchError", () => {
+  it("renders default message when no message prop", () => {
+    render(<FetchError />);
+    expect(screen.getByText("データの取得に失敗しました")).toBeTruthy();
+  });
+
+  it("renders custom message", () => {
+    render(<FetchError message="カスタムエラー" />);
+    expect(screen.getByText("カスタムエラー")).toBeTruthy();
+  });
+
+  it("renders retry button when onRetry is provided", () => {
+    const onRetry = vi.fn();
+    render(<FetchError onRetry={onRetry} />);
+    const button = screen.getByRole("button", { name: /再読み込み/ });
+    expect(button).toBeTruthy();
+  });
+
+  it("does not render retry button when onRetry is not provided", () => {
+    render(<FetchError />);
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("calls onRetry when retry button is clicked", () => {
+    const onRetry = vi.fn();
+    render(<FetchError onRetry={onRetry} />);
+    fireEvent.click(screen.getByRole("button", { name: /再読み込み/ }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders error icon", () => {
+    const { container } = render(<FetchError />);
+    const svg = container.querySelector("svg");
+    expect(svg).toBeTruthy();
+  });
+});

--- a/src/components/fetch-error.tsx
+++ b/src/components/fetch-error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface FetchErrorProps {
+  message?: string;
+  onRetry?: () => void;
+}
+
+export function FetchError({
+  message = "データの取得に失敗しました",
+  onRetry,
+}: FetchErrorProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center space-y-3">
+      <AlertCircle className="h-8 w-8 text-destructive" />
+      <p className="text-sm text-destructive">{message}</p>
+      {onRetry && (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          <RefreshCw className="h-4 w-4 mr-1.5" />
+          再読み込み
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/components/round-history/round-list.tsx
+++ b/src/components/round-history/round-list.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
 import { Score } from "@/types/database";
 import { formatMonthGroup } from "@/utils/round-stats";
 import { RoundCard } from "./round-card";
 import { Loader2 } from "lucide-react";
+import { FetchError } from "@/components/fetch-error";
 
 interface RoundData {
   id: string;
@@ -26,43 +27,48 @@ interface RoundHistoryTabProps {
 export function RoundHistoryTab({ memberId }: RoundHistoryTabProps) {
   const [rounds, setRounds] = useState<RoundData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
 
-  useEffect(() => {
-    async function fetchRounds() {
-      const { data, error } = await supabase
-        .from("rounds")
-        .select(
-          `id, date, tee_color, weather, out_course_name, in_course_name, ext_course_labels,
-          courses(name, pref),
-          scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail)`
-        )
-        .eq("member_id", memberId)
-        .order("date", { ascending: false });
+  const fetchRounds = useCallback(async () => {
+    setIsLoading(true);
+    setFetchError(null);
 
-      if (error) {
-        console.error("Failed to fetch rounds:", error);
-        setIsLoading(false);
-        return;
-      }
+    const { data, error } = await supabase
+      .from("rounds")
+      .select(
+        `id, date, tee_color, weather, out_course_name, in_course_name, ext_course_labels,
+        courses(name, pref),
+        scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail)`
+      )
+      .eq("member_id", memberId)
+      .order("date", { ascending: false });
 
-      const roundData: RoundData[] = (data ?? []).map((r) => ({
-        id: r.id,
-        date: r.date,
-        tee_color: r.tee_color,
-        weather: r.weather,
-        out_course_name: r.out_course_name,
-        in_course_name: r.in_course_name,
-        ext_course_labels: (r.ext_course_labels as string[]) ?? [],
-        courses: r.courses as unknown as { name: string; pref: string | null } | null,
-        scores: (r.scores as unknown as Score[]) ?? [],
-      }));
-
-      setRounds(roundData);
+    if (error) {
+      console.error("Failed to fetch rounds:", error);
+      setFetchError("ラウンド履歴の取得に失敗しました。通信状況を確認してください。");
       setIsLoading(false);
+      return;
     }
 
-    fetchRounds();
+    const roundData: RoundData[] = (data ?? []).map((r) => ({
+      id: r.id,
+      date: r.date,
+      tee_color: r.tee_color,
+      weather: r.weather,
+      out_course_name: r.out_course_name,
+      in_course_name: r.in_course_name,
+      ext_course_labels: (r.ext_course_labels as string[]) ?? [],
+      courses: r.courses as unknown as { name: string; pref: string | null } | null,
+      scores: (r.scores as unknown as Score[]) ?? [],
+    }));
+
+    setRounds(roundData);
+    setIsLoading(false);
   }, [memberId]);
+
+  useEffect(() => {
+    fetchRounds();
+  }, [fetchRounds]);
 
   if (isLoading) {
     return (
@@ -70,6 +76,10 @@ export function RoundHistoryTab({ memberId }: RoundHistoryTabProps) {
         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
       </div>
     );
+  }
+
+  if (fetchError) {
+    return <FetchError message={fetchError} onRetry={fetchRounds} />;
   }
 
   if (rounds.length === 0) {


### PR DESCRIPTION
## Summary
- 共通エラー表示コンポーネント `FetchError` を新規作成（エラーメッセージ + 再読み込みボタン）
- 全データ取得箇所（ランキング、マイページ、ラウンド履歴、コース分析）でエラー時にユーザーへエラーを表示するよう改善
- エラー時に「データなし」と誤表示される問題を解消

## Test plan
- [x] FetchErrorコンポーネントのユニットテスト（6件パス）
- [ ] 各ページでネットワークエラー時にエラーメッセージが表示されることを確認
- [ ] 再読み込みボタンで再取得されることを確認

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)