### PR TITLE
feat: サブコース・ホール紐付けの追加

### DIFF
--- a/src/app/api/rounds/[id]/scores/route.ts
+++ b/src/app/api/rounds/[id]/scores/route.ts
@@ -175,15 +175,16 @@ export async function POST(
   try {
     const { id: roundId } = await params;
     const body = await request.json();
-    const { scores, course_label } = body as {
+    const { scores, course_label, sub_course_ids } = body as {
       scores: AddHalfScoreInput[];
       course_label: string;
+      sub_course_ids?: string[];
     };
 
     // ラウンドの所有者チェック
     const { data: round, error: roundError } = await supabase
       .from("rounds")
-      .select("id, member_id, ext_course_labels")
+      .select("id, member_id, ext_course_labels, played_sub_course_ids")
       .eq("id", roundId)
       .single();
 
@@ -243,13 +244,21 @@ export async function POST(
       );
     }
 
-    // ext_course_labels を更新
+    // ext_course_labels + played_sub_course_ids を更新
     const currentLabels: string[] = (round.ext_course_labels as string[]) ?? [];
     const updatedLabels = [...currentLabels, course_label];
 
+    const currentSubCourseIds: string[] = (round.played_sub_course_ids as string[]) ?? [];
+    const updatedSubCourseIds = sub_course_ids
+      ? [...currentSubCourseIds, ...sub_course_ids]
+      : currentSubCourseIds;
+
     const { error: updateError } = await supabase
       .from("rounds")
-      .update({ ext_course_labels: updatedLabels })
+      .update({
+        ext_course_labels: updatedLabels,
+        played_sub_course_ids: updatedSubCourseIds,
+      })
       .eq("id", roundId);
 
     if (updateError) {

--- a/src/app/input/detailed/page.tsx
+++ b/src/app/input/detailed/page.tsx
@@ -13,6 +13,7 @@ import { supabase } from "@/lib/supabase";
 import { authFetch } from "@/lib/api-client";
 import { aggregateHoleData } from "@/utils/shot-aggregation";
 import { validateScores } from "@/utils/score-validation";
+import { buildCourseHoleIdMap } from "@/utils/resolve-course-holes";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { enqueue, isNetworkError, CreateRoundPayload, AddScoresPayload } from "@/lib/offline-queue";
 import { Suspense } from "react";
@@ -419,6 +420,11 @@ function DetailedInputContent() {
         }).filter((n): n is string => n !== null);
         const courseLabel = subCourseNames[0] ?? "追加";
 
+        // 追加モード用の course_hole_id マッピング
+        const addCourseHoleIdMap = selectedCourse
+          ? buildCourseHoleIdMap(selectedCourse.sub_courses, roundData.subCourseIds, addModeHoleOffset)
+          : new Map<number, string>();
+
         const scores = aggregated.map((agg) => ({
           par: agg.par,
           score: agg.score,
@@ -430,12 +436,17 @@ function DetailedInputContent() {
           distance: agg.distance,
           pin_position: agg.pin_position,
           shots_detail: agg.shots_detail,
+          course_hole_id: addCourseHoleIdMap.get(agg.hole_number) ?? null,
         }));
 
         const res = await authFetch(`/api/rounds/${addToRoundId}/scores`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ scores, course_label: courseLabel }),
+          body: JSON.stringify({
+            scores,
+            course_label: courseLabel,
+            sub_course_ids: roundData.subCourseIds,
+          }),
         });
 
         if (!res.ok) {
@@ -462,12 +473,14 @@ function DetailedInputContent() {
           const sc = selectedCourse?.sub_courses.find((s) => s.id === scId);
           return sc?.name ?? null;
         }).filter((n): n is string => n !== null);
-        const outCourseName = subCourseNames[0] ?? null;
+        // サブコースが未登録/未選択の場合はデフォルトで OUT / IN をセット
+        const holeCount = aggregated.length;
+        const outCourseName = subCourseNames[0] ?? (holeCount > 0 ? "OUT" : null);
         const inCourseName = subCourseNames.length > 1
           ? subCourseNames.slice(1).join(" / ")
-          : null;
+          : (holeCount > 9 ? "IN" : null);
 
-        // rounds テーブルに insert
+        // rounds テーブルに insert（旧カラム + 新カラム両方書き）
         const { data: round, error: roundError } = await supabase
           .from("rounds")
           .insert({
@@ -477,6 +490,7 @@ function DetailedInputContent() {
             tee_color: roundData.teeColor,
             out_course_name: outCourseName,
             in_course_name: inCourseName,
+            played_sub_course_ids: roundData.subCourseIds,
           })
           .select()
           .single();
@@ -492,7 +506,12 @@ function DetailedInputContent() {
           return;
         }
 
-        // scores テーブルに一括 insert
+        // course_hole_id マッピングを構築
+        const courseHoleIdMap = selectedCourse
+          ? buildCourseHoleIdMap(selectedCourse.sub_courses, roundData.subCourseIds)
+          : new Map<number, string>();
+
+        // scores テーブルに一括 insert（course_hole_id 付き）
         const scoreRecords = aggregated.map((agg) => ({
           round_id: round.id,
           hole_number: agg.hole_number,
@@ -506,6 +525,7 @@ function DetailedInputContent() {
           penalty: agg.penalty,
           pin_position: agg.pin_position,
           shots_detail: agg.shots_detail,
+          course_hole_id: courseHoleIdMap.get(agg.hole_number) ?? null,
         }));
 
         const { error: scoresError } = await supabase
@@ -551,6 +571,10 @@ function DetailedInputContent() {
             return sc?.name ?? null;
           }).filter((n): n is string => n !== null);
 
+          const offlineCourseHoleIdMap = selectedCourse
+            ? buildCourseHoleIdMap(selectedCourse.sub_courses, roundData.subCourseIds)
+            : new Map<number, string>();
+
           enqueue("create-round", {
             memberId: member.id,
             courseName: roundData.courseName,
@@ -560,6 +584,7 @@ function DetailedInputContent() {
             outCourseName: scNames[0] ?? null,
             inCourseName: scNames.length > 1 ? scNames.slice(1).join(" / ") : null,
             imageUrl: null,
+            playedSubCourseIds: roundData.subCourseIds,
             scores: agg.map((a) => ({
               hole_number: a.hole_number,
               par: a.par,
@@ -572,6 +597,7 @@ function DetailedInputContent() {
               penalty: a.penalty,
               pin_position: a.pin_position,
               shots_detail: a.shots_detail,
+              course_hole_id: offlineCourseHoleIdMap.get(a.hole_number) ?? null,
             })),
           } satisfies CreateRoundPayload);
         }

--- a/src/app/input/page.tsx
+++ b/src/app/input/page.tsx
@@ -336,8 +336,8 @@ function InputContent() {
           date: roundDate,
           tee_color: teeColor,
           image_url: imageUrl,
-          out_course_name: outCourseName || null,
-          in_course_name: inCourseName || null,
+          out_course_name: outCourseName || (scores.length > 0 ? "OUT" : null),
+          in_course_name: inCourseName || (scores.length > 9 ? "IN" : null),
         })
         .select()
         .single();

--- a/src/app/my-stats/rounds/[id]/page.tsx
+++ b/src/app/my-stats/rounds/[id]/page.tsx
@@ -15,6 +15,8 @@ import { Score, FairwayResult } from "@/types/database";
 import { Shot } from "@/types/shot";
 import { calculateRoundSummary, formatRoundDate } from "@/utils/round-stats";
 import { parseShots } from "@/utils/course-stats";
+import { fetchSectionLabelsFromIds } from "@/utils/fetch-section-labels";
+import { getFallbackSectionLabels } from "@/utils/resolve-section-labels";
 import { RoundSummaryStats } from "@/components/round-history/round-summary-stats";
 import { ScorecardTable } from "@/components/round-history/scorecard-table";
 import { ScoreDistributionChart } from "@/components/round-history/score-distribution-chart";
@@ -35,6 +37,7 @@ interface RoundDetail {
   out_course_name: string | null;
   in_course_name: string | null;
   ext_course_labels: string[];
+  played_sub_course_ids: string[];
   courses: { id: string; name: string; pref: string | null } | null;
   scores: Score[];
 }
@@ -43,9 +46,9 @@ async function fetchRoundData(roundId: string, memberId: string): Promise<RoundD
   const { data, error: fetchError } = await supabase
     .from("rounds")
     .select(
-      `id, member_id, date, tee_color, weather, out_course_name, in_course_name, ext_course_labels,
+      `id, member_id, date, tee_color, weather, out_course_name, in_course_name, ext_course_labels, played_sub_course_ids,
       courses(id, name, pref),
-      scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail)`
+      scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail, course_hole_id)`
     )
     .eq("id", roundId)
     .single();
@@ -71,6 +74,7 @@ async function fetchRoundData(roundId: string, memberId: string): Promise<RoundD
     out_course_name: data.out_course_name,
     in_course_name: data.in_course_name,
     ext_course_labels: (data.ext_course_labels as string[]) ?? [],
+    played_sub_course_ids: (data.played_sub_course_ids as string[]) ?? [],
     courses: data.courses as unknown as { id: string; name: string; pref: string | null } | null,
     scores: (data.scores as unknown as Score[]) ?? [],
   };
@@ -90,6 +94,7 @@ function RoundDetailContent() {
   const roundId = params.id as string;
 
   const [round, setRound] = useState<RoundDetail | null>(null);
+  const [sectionLabels, setSectionLabels] = useState<string[] | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isEditMode, setIsEditMode] = useState(false);
@@ -112,14 +117,23 @@ function RoundDetailContent() {
     let cancelled = false;
 
     fetchRoundData(roundId, member.id)
-      .then((data) => {
+      .then(async (data) => {
+        if (cancelled) return;
+        setRound(data);
+        setIsLoading(false);
+        if (data.scores.length > 0) {
+          const first = [...data.scores].sort((a, b) => a.hole_number - b.hole_number)[0];
+          setSelectedHole(first.hole_number);
+        }
+        // セクションラベル解決: 新カラム優先 → 旧カラムフォールバック
+        let resolvedLabels: string[] | null = null;
+        if (data.played_sub_course_ids.length > 0) {
+          resolvedLabels = await fetchSectionLabelsFromIds(data.played_sub_course_ids);
+        }
         if (!cancelled) {
-          setRound(data);
-          setIsLoading(false);
-          if (data.scores.length > 0) {
-            const first = [...data.scores].sort((a, b) => a.hole_number - b.hole_number)[0];
-            setSelectedHole(first.hole_number);
-          }
+          setSectionLabels(
+            resolvedLabels ?? getFallbackSectionLabels(data.out_course_name, data.in_course_name, data.ext_course_labels)
+          );
         }
       })
       .catch((err) => {
@@ -260,9 +274,9 @@ function RoundDetailContent() {
                 {round.weather}
               </Badge>
             )}
-            {round.out_course_name && round.in_course_name && (
+            {sectionLabels && sectionLabels.length > 0 && (
               <span className="text-xs text-muted-foreground">
-                {round.out_course_name} / {round.in_course_name}
+                {sectionLabels.join(" / ")}
               </span>
             )}
           </div>
@@ -311,7 +325,7 @@ function RoundDetailContent() {
           <CardTitle>スコアカード</CardTitle>
         </CardHeader>
         <CardContent>
-          <ScorecardTable scores={scores} extCourseLabels={round.ext_course_labels} />
+          <ScorecardTable scores={scores} extCourseLabels={round.ext_course_labels} sectionLabels={sectionLabels ?? undefined} />
         </CardContent>
       </Card>
 

--- a/src/components/round-history/round-card.tsx
+++ b/src/components/round-history/round-card.tsx
@@ -15,9 +15,12 @@ interface RoundCardProps {
     out_course_name: string | null;
     in_course_name: string | null;
     ext_course_labels?: string[];
+    played_sub_course_ids?: string[];
     courses: { name: string; pref: string | null } | null;
     scores: Score[];
   };
+  /** 解決済みセクションラベル（親で解決） */
+  sectionLabels?: string[];
 }
 
 const WEATHER_ICONS: Record<string, string> = {
@@ -59,7 +62,7 @@ function ScoreSymbolRow({ scores, label, total }: { scores: Score[]; label: stri
   );
 }
 
-export function RoundCard({ round }: RoundCardProps) {
+export function RoundCard({ round, sectionLabels }: RoundCardProps) {
   const scores = round.scores;
   const summary = calculateRoundSummary(scores);
   const overPar = summary.totalScore - summary.totalPar;
@@ -82,19 +85,21 @@ export function RoundCard({ round }: RoundCardProps) {
   const courseName = round.courses?.name ?? "不明なコース";
   const extLabels = round.ext_course_labels ?? [];
 
-  // Build labels for each 9-hole group
-  const outLabel = round.out_course_name || "OUT";
-  const inLabel = round.in_course_name || "IN";
-  const ext1Label = extLabels[0] || "EXT1";
-  const ext2Label = extLabels[1] || "EXT2";
+  // Build labels: sectionLabels優先 → 旧カラムフォールバック
+  const outLabel = sectionLabels?.[0] ?? (round.out_course_name || "OUT");
+  const inLabel = sectionLabels?.[1] ?? (round.in_course_name || "IN");
+  const ext1Label = sectionLabels?.[2] ?? (extLabels[0] || "EXT1");
+  const ext2Label = sectionLabels?.[3] ?? (extLabels[1] || "EXT2");
 
   const outTotal = outScores.reduce((sum, s) => sum + s.score, 0);
   const inTotal = inScores.reduce((sum, s) => sum + s.score, 0);
   const ext1Total = ext1Scores.reduce((sum, s) => sum + s.score, 0);
   const ext2Total = ext2Scores.reduce((sum, s) => sum + s.score, 0);
 
-  // Course names display
-  const courseNames = [round.out_course_name, round.in_course_name, ...extLabels].filter(Boolean);
+  // Course names display: sectionLabels優先
+  const courseNames = sectionLabels
+    ? sectionLabels.filter(Boolean)
+    : [round.out_course_name, round.in_course_name, ...extLabels].filter(Boolean);
 
   return (
     <Link href={`/my-stats/rounds/${round.id}`}>

--- a/src/components/round-history/round-list.tsx
+++ b/src/components/round-history/round-list.tsx
@@ -7,6 +7,7 @@ import { formatMonthGroup } from "@/utils/round-stats";
 import { RoundCard } from "./round-card";
 import { Loader2 } from "lucide-react";
 import { FetchError } from "@/components/fetch-error";
+import { getFallbackSectionLabels } from "@/utils/resolve-section-labels";
 
 interface RoundData {
   id: string;
@@ -16,6 +17,7 @@ interface RoundData {
   out_course_name: string | null;
   in_course_name: string | null;
   ext_course_labels: string[];
+  played_sub_course_ids: string[];
   courses: { name: string; pref: string | null } | null;
   scores: Score[];
 }
@@ -26,6 +28,7 @@ interface RoundHistoryTabProps {
 
 export function RoundHistoryTab({ memberId }: RoundHistoryTabProps) {
   const [rounds, setRounds] = useState<RoundData[]>([]);
+  const [subCourseNameMap, setSubCourseNameMap] = useState<Map<string, string>>(new Map());
   const [isLoading, setIsLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
 
@@ -36,9 +39,9 @@ export function RoundHistoryTab({ memberId }: RoundHistoryTabProps) {
     const { data, error } = await supabase
       .from("rounds")
       .select(
-        `id, date, tee_color, weather, out_course_name, in_course_name, ext_course_labels,
+        `id, date, tee_color, weather, out_course_name, in_course_name, ext_course_labels, played_sub_course_ids,
         courses(name, pref),
-        scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail)`
+        scores(id, round_id, hole_number, par, distance, score, putts, fairway_result, ob, bunker, penalty, pin_position, shots_detail, course_hole_id)`
       )
       .eq("member_id", memberId)
       .order("date", { ascending: false });
@@ -58,11 +61,30 @@ export function RoundHistoryTab({ memberId }: RoundHistoryTabProps) {
       out_course_name: r.out_course_name,
       in_course_name: r.in_course_name,
       ext_course_labels: (r.ext_course_labels as string[]) ?? [],
+      played_sub_course_ids: (r.played_sub_course_ids as string[]) ?? [],
       courses: r.courses as unknown as { name: string; pref: string | null } | null,
       scores: (r.scores as unknown as Score[]) ?? [],
     }));
 
     setRounds(roundData);
+
+    // 全ラウンドの played_sub_course_ids を集めて一括でサブコース名を取得
+    const allSubCourseIds = new Set<string>();
+    for (const r of roundData) {
+      for (const id of r.played_sub_course_ids) {
+        allSubCourseIds.add(id);
+      }
+    }
+    if (allSubCourseIds.size > 0) {
+      const { data: scData } = await supabase
+        .from("course_sub_courses")
+        .select("id, name")
+        .in("id", Array.from(allSubCourseIds));
+      if (scData) {
+        setSubCourseNameMap(new Map(scData.map((d) => [d.id, d.name])));
+      }
+    }
+
     setIsLoading(false);
   }, [memberId]);
 
@@ -112,9 +134,14 @@ export function RoundHistoryTab({ memberId }: RoundHistoryTabProps) {
             {group.month}
           </h3>
           <div className="space-y-2">
-            {group.rounds.map((round) => (
-              <RoundCard key={round.id} round={round} />
-            ))}
+            {group.rounds.map((round) => {
+              const labels = round.played_sub_course_ids.length > 0
+                ? round.played_sub_course_ids.map((id) => subCourseNameMap.get(id) ?? "???")
+                : getFallbackSectionLabels(round.out_course_name, round.in_course_name, round.ext_course_labels);
+              return (
+                <RoundCard key={round.id} round={round} sectionLabels={labels} />
+              );
+            })}
           </div>
         </div>
       ))}

--- a/src/components/round-history/scorecard-table.tsx
+++ b/src/components/round-history/scorecard-table.tsx
@@ -13,7 +13,10 @@ import {
 
 interface ScorecardTableProps {
   scores: Score[];
+  /** @deprecated Use sectionLabels instead */
   extCourseLabels?: string[];
+  /** 解決済みセクションラベル（新カラム優先で親が解決） */
+  sectionLabels?: string[];
 }
 
 function HalfTable({
@@ -129,9 +132,9 @@ export function getSectionLabels(extCourseLabels: string[] = []): string[] {
   return ["OUT", "IN", ...extCourseLabels];
 }
 
-export function ScorecardTable({ scores, extCourseLabels = [] }: ScorecardTableProps) {
+export function ScorecardTable({ scores, extCourseLabels = [], sectionLabels }: ScorecardTableProps) {
   const sorted = [...scores].sort((a, b) => a.hole_number - b.hole_number);
-  const labels = getSectionLabels(extCourseLabels);
+  const labels = sectionLabels ?? getSectionLabels(extCourseLabels);
 
   // 9ホールごとにセクション分割（最大4セクション = 36H）
   const sections: { label: string; holes: Score[]; startHole: number }[] = [];

--- a/src/lib/offline-queue.ts
+++ b/src/lib/offline-queue.ts
@@ -14,6 +14,7 @@ export interface CreateRoundPayload {
   outCourseName: string | null;
   inCourseName: string | null;
   imageUrl: string | null;
+  playedSubCourseIds?: string[];
   scores: {
     hole_number: number;
     par: number;
@@ -26,6 +27,7 @@ export interface CreateRoundPayload {
     penalty: number;
     pin_position?: string | null;
     shots_detail?: unknown[] | null;
+    course_hole_id?: string | null;
   }[];
 }
 
@@ -145,6 +147,7 @@ async function processCreateRound(payload: CreateRoundPayload): Promise<void> {
       image_url: payload.imageUrl,
       out_course_name: payload.outCourseName,
       in_course_name: payload.inCourseName,
+      played_sub_course_ids: payload.playedSubCourseIds ?? [],
     })
     .select()
     .single();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -98,6 +98,7 @@ export interface Round {
   out_course_name: string | null;
   in_course_name: string | null;
   ext_course_labels: string[];
+  played_sub_course_ids: string[];
 }
 
 export interface Score {
@@ -114,6 +115,7 @@ export interface Score {
   penalty: number;
   pin_position: PinPosition | null;
   shots_detail: unknown[] | null;
+  course_hole_id: string | null;
 }
 
 /** Round with nested scores and course info */

--- a/src/utils/add-half-validation.test.ts
+++ b/src/utils/add-half-validation.test.ts
@@ -267,6 +267,7 @@ describe("buildScoreRecords", () => {
       distance: 480,
       pin_position: null,
       shots_detail: null,
+      course_hole_id: null,
     });
   });
 });

--- a/src/utils/add-half-validation.ts
+++ b/src/utils/add-half-validation.ts
@@ -13,6 +13,7 @@ export interface AddHalfScoreInput {
   distance?: number | null;
   pin_position?: string | null;
   shots_detail?: unknown[] | null;
+  course_hole_id?: string | null;
 }
 
 export interface AddHalfValidationResult {
@@ -121,5 +122,6 @@ export function buildScoreRecords(
     distance: s.distance ?? null,
     pin_position: s.pin_position ?? null,
     shots_detail: s.shots_detail ?? null,
+    course_hole_id: s.course_hole_id ?? null,
   }));
 }

--- a/src/utils/fetch-section-labels.ts
+++ b/src/utils/fetch-section-labels.ts
@@ -1,0 +1,28 @@
+import { supabase } from "@/lib/supabase";
+
+/**
+ * played_sub_course_ids からサブコース名を取得してセクションラベルを返す。
+ * 取得に失敗した場合や空配列の場合は null を返す（フォールバック用）。
+ */
+export async function fetchSectionLabelsFromIds(
+  playedSubCourseIds: string[]
+): Promise<string[] | null> {
+  if (!playedSubCourseIds || playedSubCourseIds.length === 0) {
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from("course_sub_courses")
+    .select("id, name")
+    .in("id", playedSubCourseIds);
+
+  if (error || !data) {
+    return null;
+  }
+
+  // played_sub_course_ids の順番を維持
+  const nameMap = new Map(data.map((d) => [d.id, d.name]));
+  const labels = playedSubCourseIds.map((id) => nameMap.get(id) ?? `H?`);
+
+  return labels;
+}

--- a/src/utils/resolve-course-holes.test.ts
+++ b/src/utils/resolve-course-holes.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { buildCourseHoleIdMap } from "./resolve-course-holes";
+import { SubCourseWithHoles } from "@/types/database";
+
+const makeSubCourse = (
+  id: string,
+  name: string,
+  holes: { id: string; hole_number: number; par: 3 | 4 | 5 | 6 }[]
+): SubCourseWithHoles => ({
+  id,
+  course_id: "course-1",
+  name,
+  hole_count: holes.length,
+  sort_order: 0,
+  holes: holes.map((h) => ({
+    id: h.id,
+    sub_course_id: id,
+    hole_number: h.hole_number,
+    par: h.par,
+    handicap: null,
+    distances: {},
+  })),
+});
+
+describe("buildCourseHoleIdMap", () => {
+  const outCourse = makeSubCourse("sc-out", "OUT", [
+    { id: "h1", hole_number: 1, par: 4 },
+    { id: "h2", hole_number: 2, par: 3 },
+    { id: "h3", hole_number: 3, par: 5 },
+  ]);
+  const inCourse = makeSubCourse("sc-in", "IN", [
+    { id: "h4", hole_number: 1, par: 4 },
+    { id: "h5", hole_number: 2, par: 4 },
+    { id: "h6", hole_number: 3, par: 3 },
+  ]);
+  const subCourses = [outCourse, inCourse];
+
+  it("should map hole numbers to course_hole_ids in selected order", () => {
+    const map = buildCourseHoleIdMap(subCourses, ["sc-out", "sc-in"]);
+    expect(map.get(1)).toBe("h1");
+    expect(map.get(2)).toBe("h2");
+    expect(map.get(3)).toBe("h3");
+    expect(map.get(4)).toBe("h4");
+    expect(map.get(5)).toBe("h5");
+    expect(map.get(6)).toBe("h6");
+    expect(map.size).toBe(6);
+  });
+
+  it("should respect reversed sub-course order", () => {
+    const map = buildCourseHoleIdMap(subCourses, ["sc-in", "sc-out"]);
+    expect(map.get(1)).toBe("h4"); // IN course first
+    expect(map.get(2)).toBe("h5");
+    expect(map.get(3)).toBe("h6");
+    expect(map.get(4)).toBe("h1"); // OUT course second
+    expect(map.get(5)).toBe("h2");
+    expect(map.get(6)).toBe("h3");
+  });
+
+  it("should apply hole offset for add mode", () => {
+    const map = buildCourseHoleIdMap(subCourses, ["sc-in"], 9);
+    expect(map.get(10)).toBe("h4");
+    expect(map.get(11)).toBe("h5");
+    expect(map.get(12)).toBe("h6");
+    expect(map.size).toBe(3);
+  });
+
+  it("should return empty map when no sub courses match", () => {
+    const map = buildCourseHoleIdMap(subCourses, ["non-existent"]);
+    expect(map.size).toBe(0);
+  });
+
+  it("should return empty map for empty selectedSubCourseIds", () => {
+    const map = buildCourseHoleIdMap(subCourses, []);
+    expect(map.size).toBe(0);
+  });
+
+  it("should sort holes by hole_number within each sub-course", () => {
+    const unsortedCourse = makeSubCourse("sc-unsorted", "UNSORTED", [
+      { id: "h-c", hole_number: 3, par: 5 },
+      { id: "h-a", hole_number: 1, par: 4 },
+      { id: "h-b", hole_number: 2, par: 3 },
+    ]);
+    const map = buildCourseHoleIdMap([unsortedCourse], ["sc-unsorted"]);
+    expect(map.get(1)).toBe("h-a");
+    expect(map.get(2)).toBe("h-b");
+    expect(map.get(3)).toBe("h-c");
+  });
+});

--- a/src/utils/resolve-course-holes.ts
+++ b/src/utils/resolve-course-holes.ts
@@ -1,0 +1,28 @@
+import { SubCourseWithHoles } from "@/types/database";
+
+/**
+ * 選択されたサブコースのID順にホールを並べ、
+ * hole_number → course_hole_id のマッピングを返す。
+ * コースマスタ未登録の場合は空マップを返す。
+ */
+export function buildCourseHoleIdMap(
+  subCourses: SubCourseWithHoles[],
+  selectedSubCourseIds: string[],
+  holeOffset: number = 0
+): Map<number, string> {
+  const map = new Map<number, string>();
+  let holeNum = holeOffset + 1;
+
+  for (const scId of selectedSubCourseIds) {
+    const sc = subCourses.find((s) => s.id === scId);
+    if (!sc) continue;
+
+    const sortedHoles = [...sc.holes].sort((a, b) => a.hole_number - b.hole_number);
+    for (const h of sortedHoles) {
+      map.set(holeNum, h.id);
+      holeNum++;
+    }
+  }
+
+  return map;
+}

--- a/src/utils/resolve-section-labels.test.ts
+++ b/src/utils/resolve-section-labels.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { getFallbackSectionLabels, resolveSectionLabels } from "./resolve-section-labels";
+
+describe("getFallbackSectionLabels", () => {
+  it("should return OUT/IN when both are null", () => {
+    expect(getFallbackSectionLabels(null, null)).toEqual(["OUT", "IN"]);
+  });
+
+  it("should use provided names when available", () => {
+    expect(getFallbackSectionLabels("東", "西")).toEqual(["東", "西"]);
+  });
+
+  it("should include ext_course_labels", () => {
+    expect(getFallbackSectionLabels("東", "西", ["南"])).toEqual(["東", "西", "南"]);
+  });
+
+  it("should fallback partially when only one is null", () => {
+    expect(getFallbackSectionLabels("東", null)).toEqual(["東", "IN"]);
+    expect(getFallbackSectionLabels(null, "西")).toEqual(["OUT", "西"]);
+  });
+
+  it("should handle empty ext_course_labels", () => {
+    expect(getFallbackSectionLabels("OUT", "IN", [])).toEqual(["OUT", "IN"]);
+  });
+});
+
+describe("resolveSectionLabels", () => {
+  it("should resolve IDs to names using the map", () => {
+    const nameMap = new Map([
+      ["id-1", "東"],
+      ["id-2", "西"],
+    ]);
+    expect(resolveSectionLabels(["id-1", "id-2"], nameMap)).toEqual(["東", "西"]);
+  });
+
+  it("should return ??? for unknown IDs", () => {
+    const nameMap = new Map([["id-1", "東"]]);
+    expect(resolveSectionLabels(["id-1", "id-unknown"], nameMap)).toEqual(["東", "???"]);
+  });
+
+  it("should return empty array for empty input", () => {
+    expect(resolveSectionLabels([], new Map())).toEqual([]);
+  });
+
+  it("should preserve order of played_sub_course_ids", () => {
+    const nameMap = new Map([
+      ["id-1", "東"],
+      ["id-2", "西"],
+      ["id-3", "南"],
+    ]);
+    expect(resolveSectionLabels(["id-3", "id-1"], nameMap)).toEqual(["南", "東"]);
+  });
+});

--- a/src/utils/resolve-section-labels.ts
+++ b/src/utils/resolve-section-labels.ts
@@ -1,0 +1,26 @@
+/**
+ * 同期版: すでに取得済みのサブコース名マップからラベルを解決する。
+ * クライアントサイドで一括取得した結果を使う場合に利用。
+ */
+export function resolveSectionLabels(
+  playedSubCourseIds: string[],
+  subCourseNameMap: Map<string, string>
+): string[] {
+  return playedSubCourseIds.map((id) => subCourseNameMap.get(id) ?? "???");
+}
+
+/**
+ * 旧カラムからフォールバックでセクションラベルを生成する。
+ * played_sub_course_ids が空の場合に使用。
+ */
+export function getFallbackSectionLabels(
+  outCourseName: string | null,
+  inCourseName: string | null,
+  extCourseLabels: string[] = []
+): string[] {
+  return [
+    outCourseName || "OUT",
+    inCourseName || "IN",
+    ...extCourseLabels,
+  ];
+}

--- a/supabase/004_sub_course_linking.sql
+++ b/supabase/004_sub_course_linking.sql
@@ -1,0 +1,23 @@
+-- ==========================================
+-- Golf Dashboard - Sub Course Linking Migration
+-- ==========================================
+-- rounds に played_sub_course_ids を追加し、scores に course_hole_id を追加。
+-- 旧カラム (out_course_name, in_course_name, ext_course_labels) はそのまま残す。
+
+-- 1. rounds: ラウンドでプレイしたサブコースのID配列
+ALTER TABLE rounds
+  ADD COLUMN IF NOT EXISTS played_sub_course_ids UUID[] NOT NULL DEFAULT '{}';
+
+-- 2. scores: 各スコアが対応するコースホールのID
+ALTER TABLE scores
+  ADD COLUMN IF NOT EXISTS course_hole_id UUID REFERENCES course_holes(id);
+
+-- 3. scores.course_hole_id にインデックス（ホール別分析の高速化）
+CREATE INDEX IF NOT EXISTS idx_scores_course_hole_id
+  ON scores(course_hole_id)
+  WHERE course_hole_id IS NOT NULL;
+
+-- 4. rounds.played_sub_course_ids にGINインデックス（配列検索用）
+CREATE INDEX IF NOT EXISTS idx_rounds_played_sub_course_ids
+  ON rounds USING GIN (played_sub_course_ids)
+  WHERE played_sub_course_ids != '{}';


### PR DESCRIPTION
## Summary
- `rounds.played_sub_course_ids UUID[]` と `scores.course_hole_id UUID` を追加し、ラウンドでプレイしたサブコースと各スコアの物理ホールを紐付け可能に
- 入力側は旧カラム（`out_course_name`等）と新カラムの両方書き、表示側は新カラム優先→旧カラムフォールバックで既存データとの互換性を維持
- INスタートなどのプレイ順序も配列で保持

## 変更内容

### DB Migration (`supabase/004_sub_course_linking.sql`)
- `rounds.played_sub_course_ids UUID[]` — プレイしたサブコースのID配列（順序保持）
- `scores.course_hole_id UUID` — 各スコアが対応するcourse_holesのID（NULL許容）

### 入力側（両方書き）
- 詳細入力: `played_sub_course_ids`と`course_hole_id`を旧カラムと並行して保存
- ハーフ追加API: `sub_course_ids`を受け取り追記
- オフラインキュー: 新フィールド対応

### 表示側（新カラム優先フォールバック）
- ラウンド詳細: `played_sub_course_ids`から非同期でサブコース名取得→旧カラムにフォールバック
- ラウンド一覧: 全サブコースIDを一括取得してRoundCardにラベル渡し
- スコアカード: `sectionLabels` prop追加

### 新規ユーティリティ
- `resolve-course-holes.ts` — hole_number→course_hole_idマッピング
- `resolve-section-labels.ts` — フォールバック/マップ解決（純粋関数）
- `fetch-section-labels.ts` — Supabase経由の非同期取得

## Test plan
- [x] `resolve-course-holes.test.ts` — 6テスト（順序、オフセット、未マッチ等）
- [x] `resolve-section-labels.test.ts` — 9テスト（フォールバック、マップ解決等）
- [x] 既存テスト全265テスト通過
- [x] ビルド成功
- [ ] 本番DBでマイグレーションSQL実行後、既存ラウンドが正常に表示されることを確認
- [ ] 詳細入力で新規ラウンド保存後、`played_sub_course_ids`と`course_hole_id`がDBに入ることを確認

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)