### PR TITLE
fix: 詳細入力中の±Par表示をカップイン済みホールのみで集計

### DIFF
--- a/src/app/input/detailed/components/step-scoring.tsx
+++ b/src/app/input/detailed/components/step-scoring.tsx
@@ -253,19 +253,22 @@ export function StepScoring({
     return result;
   }, [selectedCourse, roundData.subCourseIds, roundData.holes, totalHoles]);
 
-  // スコア集計
+  // スコア集計（確定済みホール＝カップイン済みのみ）
   const stats = useMemo(() => {
     const sectionScores = subCourseInfo.map((s) => ({
       name: s.name,
-      score: s.holes.reduce((sum, h) => sum + getHoleScore(h), 0),
+      score: s.holes
+        .filter((h) => isCupIn(h.shots))
+        .reduce((sum, h) => sum + getHoleScore(h), 0),
     }));
 
-    const totalScore = roundData.holes.reduce(
+    const completedHoles = roundData.holes.filter((h) => isCupIn(h.shots));
+    const totalScore = completedHoles.reduce(
       (sum, h) => sum + getHoleScore(h),
       0
     );
-    const totalPar = roundData.holes.reduce((sum, h) => sum + h.par, 0);
-    const totalPutts = roundData.holes.reduce(
+    const totalPar = completedHoles.reduce((sum, h) => sum + h.par, 0);
+    const totalPutts = completedHoles.reduce(
       (sum, h) => sum + h.shots.filter((s) => s.type === "putt").length,
       0
     );


### PR DESCRIPTION
## Summary
- 詳細スコア入力中のサマリーバー（TOTAL/±Par/Putt）の集計対象を、全ホールからカップイン済みホールのみに変更
- ショット入力中の不要な数字変動がなくなり、ラウンドのペースが正確に把握できるように

## Test plan
- [x] 全265テスト通過
- [x] ビルド成功
- [ ] 1番ホールでボギー入力→カップイン→2番ホールに移動した時点で±Par=+1と表示されることを確認
- [ ] 2番ホールでティーショット追加してもTOTAL/±Parが変動しないことを確認

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)